### PR TITLE
Avoid sending messages in Executor::execute_sequence()

### DIFF
--- a/include/taskomat/Executor.h
+++ b/include/taskomat/Executor.h
@@ -180,7 +180,10 @@ private:
      */
     Context context_;
 
-    /// The function that is run in the execution thread.
+    /**
+     * This is the function running in the execution thread: It calls Sequence::execute()
+     * and silently swallows all exceptions.
+     */
     static void execute_sequence(Sequence sequence, Context context,
                                  std::shared_ptr<CommChannel> comm_channel) noexcept;
 };

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -79,10 +79,10 @@ void Executor::execute_sequence(Sequence sequence, Context context,
     {
         sequence.execute(context, comm.get());
     }
-    catch (const std::exception& e)
+    catch (const std::exception&)
     {
-        comm->queue_.push(Message(Message::Type::sequence_stopped_with_error, e.what(),
-                                  Clock::now(), 0));
+        // Silently ignore any thrown exception - the sequence already takes care of
+        // sending the appropriate messages.
     }
 }
 


### PR DESCRIPTION
This avoids duplicated "sequence stopped" errors, as observed by Fini in one of the old Gitlab issues. `Executor::execute_sequence()` is just a wrapper around `Sequence::execute()`, which already takes care of sending the necessary messages.
