### PR TITLE
Step: Prevent labels that we can not serialize

### DIFF
--- a/include/taskomat/Step.h
+++ b/include/taskomat/Step.h
@@ -232,6 +232,9 @@ public:
     /**
      * Set the label.
      * This call also updates the time of last modification to the current system time.
+     *
+     * Labels must not start or end with whitespace; existing whitespace is
+     * silently removed.
      */
     void set_label(const std::string& label);
 

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -24,6 +24,7 @@
 
 #include <gul14/cat.h>
 #include <gul14/finalizer.h>
+#include <gul14/trim.h>
 
 #include "sol/sol.hpp"
 #include "taskomat/Error.h"
@@ -180,7 +181,7 @@ void Step::set_indentation_level(short level)
 
 void Step::set_label(const std::string& label)
 {
-    label_ = label;
+    label_ = gul14::trim(label);
     set_time_of_last_modification(Clock::now());
 }
 

--- a/tests/test_serialize_sequence.cc
+++ b/tests/test_serialize_sequence.cc
@@ -81,6 +81,17 @@ TEST_CASE("serialize_sequence: simple step", "[serialize_sequence]")
         REQUIRE(deserialize.get_label() == "This is a funny label\n-- label: NOT FUNNY");
     }
 
+    SECTION("deserialize: whitespaced label")
+    {
+        step.set_label(" L a b e l ");
+        ss << step;
+
+        Step deserialize;
+        ss >> deserialize;
+
+        REQUIRE(deserialize.get_label() == "L a b e l"); // stripped label
+    }
+
     SECTION("deserialize infinite timeout")
     {
         step.set_timeout(Step::infinite_timeout);


### PR DESCRIPTION
**[why]**
The serialisation process is designed to accept any number of whitespaces after the colon. This will suppress any whitespaces that were part of the label to be restored correctly.

**[how]**
Just forbid labels that can not be restored. Although we could instead install several other attempts to allow leading or trailing whitespaces in the label the question is: Is the freedom to allow such labels worth the more complicated code?
For this commit the answer is: no, and so whitespaced labels are forbidden.

Fixes:
https://mcs-gitlab.desy.de/doocs/doocs-high-level-support/libtaskomat/-/issues/19