### PR TITLE
Add fluid interface

### DIFF
--- a/include/taskomat/Message.h
+++ b/include/taskomat/Message.h
@@ -109,16 +109,16 @@ public:
     TimePoint get_timestamp() const { return timestamp_; };
 
     /// Set the associated index.
-    void set_index(IndexType index) { index_ = index; }
+    Message& set_index(IndexType index) { index_ = index; return *this; }
 
     /// Set the message text.
-    void set_text(const std::string& text) { text_ = text; }
+    Message& set_text(const std::string& text) { text_ = text; return *this; }
 
     /// Set the timestamp.
-    void set_timestamp(TimePoint timestamp) { timestamp_ = timestamp; };
+    Message& set_timestamp(TimePoint timestamp) { timestamp_ = timestamp; return *this; };
 
     /// Set the message type.
-    void set_type(Type type) noexcept { type_ = type; }
+    Message& set_type(Type type) noexcept { type_ = type; return *this; }
 
     friend std::ostream& operator<<(std::ostream& stream, Type const& t) {
         stream << Message::type_description_[static_cast<int>(t)];

--- a/include/taskomat/Step.h
+++ b/include/taskomat/Step.h
@@ -216,7 +216,7 @@ public:
     bool is_disabled() const noexcept { return is_disabled_; }
 
     /// Set whether the step should be disabled (or possibly executed).
-    void set_disabled(bool disable);
+    Step& set_disabled(bool disable);
 
     /**
      * Set the indentation level of this step.
@@ -227,7 +227,7 @@ public:
      *
      * \exception Error is thrown if level < 0 or level > max_indentation_level.
      */
-    void set_indentation_level(short level);
+    Step& set_indentation_level(short level);
 
     /**
      * Set the label.
@@ -236,50 +236,50 @@ public:
      * Labels must not start or end with whitespace; existing whitespace is
      * silently removed.
      */
-    void set_label(const std::string& label);
+    Step& set_label(const std::string& label);
 
     /**
      * Set whether the step should be marked as "currently running".
      *
      * This is normally done by an Executor.
      */
-    void set_running(bool is_running) { is_running_ = is_running; }
+    Step& set_running(bool is_running);
 
     /**
      * Set the script that should be executed when this step is run.
      * Syntax or semantics of the script are not checked.
      */
-    void set_script(const std::string& script);
+    Step& set_script(const std::string& script);
 
     /**
      * Set the timestamp of the last execution of this step's script.
      * This function should be called when an external execution engine starts the
      * embedded script or when the Step has been restored from serialized form.
      */
-    void set_time_of_last_execution(TimePoint t) { time_of_last_execution_ = t; }
+    Step& set_time_of_last_execution(TimePoint t);
 
     /**
      * Set the timestamp of the last modification of this step's script or label.
      * This function is only useful to restore a step from some serialized form, e.g. from
      * a file.
      */
-    void set_time_of_last_modification(TimePoint t) { time_of_last_modification_ = t; }
+    Step& set_time_of_last_modification(TimePoint t);
 
     /**
      * Set the timeout duration for executing the script.
      * Negative values set the timeout to zero.
      */
-    void set_timeout(std::chrono::milliseconds timeout);
+    Step& set_timeout(std::chrono::milliseconds timeout);
 
     /**
      * Set the type of this step.
      * This call also updates the time of last modification to the current system time.
      */
-    void set_type(Type type);
+    Step& set_type(Type type);
 
     /// Set the names of the variables that should be im-/exported from/to the script.
-    void set_used_context_variable_names(const VariableNames& used_context_variable_names);
-    void set_used_context_variable_names(VariableNames&& used_context_variable_names);
+    Step& set_used_context_variable_names(const VariableNames& used_context_variable_names);
+    Step& set_used_context_variable_names(VariableNames&& used_context_variable_names);
 
 private:
     std::string label_;

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -159,13 +159,14 @@ bool Step::execute(Context& context, CommChannel* comm, Message::IndexType index
     return result;
 }
 
-void Step::set_disabled(bool disable)
+Step& Step::set_disabled(bool disable)
 {
     is_disabled_ = disable;
     set_time_of_last_modification(Clock::now());
+    return *this;
 }
 
-void Step::set_indentation_level(short level)
+Step& Step::set_indentation_level(short level)
 {
     if (level < 0)
         throw Error(cat("Cannot set negative indentation level (", level, ')'));
@@ -177,42 +178,67 @@ void Step::set_indentation_level(short level)
     }
 
     indentation_level_ = level;
+    return *this;
 }
 
-void Step::set_label(const std::string& label)
+Step& Step::set_label(const std::string& label)
 {
     label_ = gul14::trim(label);
     set_time_of_last_modification(Clock::now());
+    return *this;
 }
 
-void Step::set_script(const std::string& script)
+Step& Step::set_running(bool is_running)
+{
+    is_running_ = is_running;
+    return *this;
+}
+
+Step& Step::set_script(const std::string& script)
 {
     script_ = script;
     set_time_of_last_modification(Clock::now());
+    return *this;
 }
 
-void Step::set_timeout(std::chrono::milliseconds timeout)
+Step& Step::set_time_of_last_execution(TimePoint t)
+{
+    time_of_last_execution_ = t;
+    return *this;
+}
+
+Step& Step::set_time_of_last_modification(TimePoint t)
+{
+    time_of_last_modification_ = t;
+    return *this;
+}
+
+Step& Step::set_timeout(std::chrono::milliseconds timeout)
 {
     if (timeout < 0s)
         timeout_ = 0s;
     else
         timeout_ = timeout;
+    return *this;
 }
 
-void Step::set_type(Type type)
+Step& Step::set_type(Type type)
 {
     type_ = type;
     set_time_of_last_modification(Clock::now());
+    return *this;
 }
 
-void Step::set_used_context_variable_names(const VariableNames& used_context_variable_names)
+Step& Step::set_used_context_variable_names(const VariableNames& used_context_variable_names)
 {
     used_context_variable_names_ = used_context_variable_names;
+    return *this;
 }
 
-void Step::set_used_context_variable_names(VariableNames&& used_context_variable_names)
+Step& Step::set_used_context_variable_names(VariableNames&& used_context_variable_names)
 {
     used_context_variable_names_ = std::move(used_context_variable_names);
+    return *this;
 }
 
 

--- a/tests/test_Message.cc
+++ b/tests/test_Message.cc
@@ -99,7 +99,7 @@ TEST_CASE("Message: set_index()", "[Message]")
 {
     Message msg;
 
-    msg.set_index(42);
+    REQUIRE(&msg.set_index(42) == &msg);
     REQUIRE(msg.get_index() == 42);
 
     msg.set_index(0);
@@ -110,7 +110,7 @@ TEST_CASE("Message: set_text()", "[Message]")
 {
     Message msg;
 
-    msg.set_text("Test");
+    REQUIRE(&msg.set_text("Test") == &msg);
     REQUIRE(msg.get_text() == "Test");
 
     msg.set_text("");
@@ -122,7 +122,7 @@ TEST_CASE("Message: set_timestamp()", "[Message]")
     const auto t0 = Clock::now();
 
     Message msg;
-    msg.set_timestamp(t0);
+    REQUIRE(&msg.set_timestamp(t0) == &msg);
     REQUIRE(msg.get_timestamp() == t0);
 
     msg.set_timestamp(TimePoint{});
@@ -133,7 +133,7 @@ TEST_CASE("Message: set_type()", "[Message]")
 {
     Message msg;
 
-    msg.set_type(Message::Type::step_started);
+    REQUIRE(&msg.set_type(Message::Type::step_started) == &msg);
     REQUIRE(msg.get_type() == Message::Type::step_started);
 
     msg.set_type(Message::Type::log_error);
@@ -144,10 +144,10 @@ TEST_CASE("Message: Dump to stream", "[Message]")
 {
     Message msg;
 
-    msg.set_type(Message::Type::step_started);
-    msg.set_timestamp(TimePoint{});
-    msg.set_text("Beware of the foxes");
-    msg.set_index(32);
+    msg.set_type(Message::Type::step_started)
+       .set_timestamp(TimePoint{})
+       .set_text("Beware of the foxes")
+       .set_index(32);
 
     std::stringstream ss{ };
     ss << msg;

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -126,7 +126,7 @@ TEST_CASE("Step: set_indentation_level()", "[Step]")
 {
     Step step;
 
-    step.set_indentation_level(3);
+    REQUIRE(&step.set_indentation_level(3) == &step);
     REQUIRE(step.get_indentation_level() == 3);
 
     step.set_indentation_level(0);
@@ -147,7 +147,7 @@ TEST_CASE("Step: set_label()", "[Step]")
     REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
     REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
 
-    step.set_label("Do nothing");
+    REQUIRE(&step.set_label("Do nothing") == &step);
     REQUIRE(step.get_label() == "Do nothing");
     REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
     REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
@@ -162,7 +162,7 @@ TEST_CASE("Step: set_running()", "[Step]")
 {
     Step step;
 
-    step.set_running(true);
+    REQUIRE(&step.set_running(true) == &step);
     REQUIRE(step.is_running() == true);
 
     step.set_running(false);
@@ -174,7 +174,7 @@ TEST_CASE("Step: set_time_of_last_execution()", "[Step]")
     Step step;
 
     auto ts = Clock::now();
-    step.set_time_of_last_execution(ts);
+    REQUIRE(&step.set_time_of_last_execution(ts) == &step);
     REQUIRE(step.get_time_of_last_execution() == ts);
 
     step.set_time_of_last_execution(ts - 42s);
@@ -186,7 +186,7 @@ TEST_CASE("Step: set_time_of_last_modification()", "[Step]")
     Step step;
 
     auto ts = Clock::now();
-    step.set_time_of_last_modification(ts);
+    REQUIRE(&step.set_time_of_last_modification(ts) == &step);
     REQUIRE(step.get_time_of_last_modification() == ts);
 
     step.set_time_of_last_modification(ts - 42s);
@@ -197,7 +197,7 @@ TEST_CASE("Step: set_timeout()", "[Step]")
 {
     Step step;
 
-    step.set_timeout(42s);
+    REQUIRE(&step.set_timeout(42s) == &step);
     REQUIRE(step.get_timeout() == 42s);
 
     step.set_timeout(-2ms);
@@ -214,7 +214,7 @@ TEST_CASE("Step: set_type()", "[Step]")
     step.set_time_of_last_modification(ts);
     REQUIRE(step.get_time_of_last_modification() == ts);
 
-    step.set_type(Step::type_while);
+    REQUIRE(&step.set_type(Step::type_while) == &step);
     REQUIRE(step.get_type() == Step::type_while);
     REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
     REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
@@ -232,7 +232,7 @@ TEST_CASE("Step: set_script()", "[Step]")
     step.set_time_of_last_modification(ts);
     REQUIRE(step.get_time_of_last_modification() == ts);
 
-    step.set_script("test");
+    REQUIRE(&step.set_script("test") == &step);
     REQUIRE(step.get_script() == "test");
     REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
     REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
@@ -247,7 +247,7 @@ TEST_CASE("Step: set_used_context_variable_names()", "[Step]")
 {
     Step step;
 
-    step.set_used_context_variable_names(VariableNames{ "b52", "a" });
+    REQUIRE(&step.set_used_context_variable_names(VariableNames{ "b52", "a" }) == &step);
     REQUIRE(step.get_used_context_variable_names() == VariableNames{ "a", "b52" });
 }
 
@@ -716,7 +716,7 @@ TEST_CASE("Step: set_disabled()", "[Step]")
     Step step;
 
     REQUIRE(step.is_disabled() == false);
-    step.set_disabled(true);
+    REQUIRE(&step.set_disabled(true) == &step);
     REQUIRE(step.is_disabled() == true);
 
     // (There are no disable_unable types anymore)

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -144,18 +144,23 @@ TEST_CASE("Step: set_indentation_level()", "[Step]")
 TEST_CASE("Step: set_label()", "[Step]")
 {
     Step step;
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time1 = step.get_time_of_last_modification();
+    REQUIRE(time1 > Clock::now() - 2s);
+    REQUIRE(time1 < Clock::now() + 2s);
 
     REQUIRE(&step.set_label("Do nothing") == &step);
     REQUIRE(step.get_label() == "Do nothing");
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time2 = step.get_time_of_last_modification();
+    REQUIRE(time2 > Clock::now() - 2s);
+    REQUIRE(time2 < Clock::now() + 2s);
+    REQUIRE(time2 > time1);
 
     step.set_label("Do something");
     REQUIRE(step.get_label() == "Do something");
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time3 = step.get_time_of_last_modification();
+    REQUIRE(time3 > Clock::now() - 2s);
+    REQUIRE(time3 < Clock::now() + 2s);
+    REQUIRE(time3 > time2);
 }
 
 TEST_CASE("Step: set_running()", "[Step]")
@@ -216,13 +221,17 @@ TEST_CASE("Step: set_type()", "[Step]")
 
     REQUIRE(&step.set_type(Step::type_while) == &step);
     REQUIRE(step.get_type() == Step::type_while);
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time1 = step.get_time_of_last_modification();
+    REQUIRE(time1 > Clock::now() - 2s);
+    REQUIRE(time1 < Clock::now() + 2s);
+    REQUIRE(time1 > ts);
 
     step.set_type(Step::type_end);
     REQUIRE(step.get_type() == Step::type_end);
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time2 = step.get_time_of_last_modification();
+    REQUIRE(time2 > Clock::now() - 2s);
+    REQUIRE(time2 < Clock::now() + 2s);
+    REQUIRE(time2 > time1);
 }
 
 TEST_CASE("Step: set_script()", "[Step]")
@@ -234,13 +243,17 @@ TEST_CASE("Step: set_script()", "[Step]")
 
     REQUIRE(&step.set_script("test") == &step);
     REQUIRE(step.get_script() == "test");
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time1 = step.get_time_of_last_modification();
+    REQUIRE(time1 > Clock::now() - 2s);
+    REQUIRE(time1 < Clock::now() + 2s);
+    REQUIRE(time1 > ts);
 
     step.set_script("test 2");
     REQUIRE(step.get_script() == "test 2");
-    REQUIRE(step.get_time_of_last_modification() > Clock::now() - 2s);
-    REQUIRE(step.get_time_of_last_modification() < Clock::now() + 2s);
+    auto time2 = step.get_time_of_last_modification();
+    REQUIRE(time2 > Clock::now() - 2s);
+    REQUIRE(time2 < Clock::now() + 2s);
+    REQUIRE(time2 > time1);
 }
 
 TEST_CASE("Step: set_used_context_variable_names()", "[Step]")


### PR DESCRIPTION
...to `Step` and `Message`.

Example from the tests:

```c++
TEST_CASE("Message: Dump to stream", "[Message]")
{
    Message msg;

    msg.set_type(Message::Type::step_started)
       .set_timestamp(TimePoint{})
       .set_text("Beware of the foxes")
       .set_index(32);

    std::stringstream ss{ };

[...]
```
----

This ALSO fixes an error in the tests, too lazy to create a separate PR.

The tests should have tested if the `modification_timestamp` has been changed on `set_*()` access, but did not actually check it.