### PR TITLE
Fix compiler warning

### DIFF
--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -33,15 +33,15 @@ using gul14::cat;
 namespace {
 
 static const char step_index_key[] =
-    "TASKOMAT_STEP_INDEX";
+    "TASKOMAT_STP_INDEX";
 static const char step_timeout_ms_since_epoch_key[] =
-    "TASKOMAT_STEP_TIMEOUT_MS_SINCE_EPOCH";
+    "TASKOMAT_STP_TO_MS";
 static const char step_timeout_s_key[] =
-    "TASKOMAT_STEP_TIMEOUT_S";
+    "TASKOMAT_STP_TO_S";
 static const char comm_channel_key[] =
-    "TASKOMAT_COMM_CHANNEL";
+    "TASKOMAT_COMM_CH";
 static const char abort_error_message_key[] =
-    "TASKOMAT_ABORT_ERROR_MESSAGE";
+    "TASKOMAT_AB_END";
 
 } // anonymous namespace
 


### PR DESCRIPTION
**[why]**
The compiler warns that our registry keys are too long:

[46/71] Compiling C++ object libtaskomat.so.0.1.2.p/src_lua_details.cc.o In file included from ../src/lua_details.h:31,
                 from ../src/lua_details.cc:27:
../include/taskomat/sol/sol/sol.hpp: In function ‘task::Message::IndexType task::get_step_idx_from_registry(lua_State*)’: ../include/taskomat/sol/sol/sol.hpp:14751:61: warning: array subscript ‘const char [37][0]’ is partly outside array bounds of ‘const char [20]’ [-Warray-bounds]
14751 |                                                 lua_getfield(L, tableindex, &key[0]);
      |                                                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
../src/lua_details.cc:35:19: note: while referencing ‘{anonymous}::step_index_key’
   35 | static const char step_index_key[] =
      |                   ^~~~~~~~~~~~~~

**[how]**
I could not find any limits on the registry keys in the Lua manual. They suggest using not strings but numbers (for example addresses of unique strings) [1]. But for some reason that is not working.

Instead we just shorten the strings to less then 20 characters (i.e. 20 including the termination \0).

Fixes: #9