### PR TITLE
Bugfix: Change lua exception handling

### DIFF
--- a/include/taskomat/Message.h
+++ b/include/taskomat/Message.h
@@ -25,6 +25,7 @@
 #ifndef TASKOMAT_MESSAGE_H_
 #define TASKOMAT_MESSAGE_H_
 
+#include <array>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/include/taskomat/lua/luaconf.h
+++ b/include/taskomat/lua/luaconf.h
@@ -782,8 +782,14 @@
 ** without modifying the main part of the file.
 */
 
+#define LUAI_THROW(L,c) \
+	throw(c)
 
+#define LUAI_TRY(L,c,a) \
+	try { a } catch(lua_longjmp*) { if ((c)->status == 0) (c)->status = -1; }
 
+#define luai_jmpbuf \
+	int  /* dummy variable */
 
 
 #endif

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -122,35 +122,25 @@ bool Step::execute(Context& context, CommChannel* comm, StepIndex index)
 
     copy_used_variables_from_context_to_lua(context, lua);
 
-    bool result = false;
+    auto protected_result = lua.safe_script(get_script(), sol::script_pass_on_error);
 
-    try
+    if (!protected_result.valid())
     {
-        auto protected_result = lua.safe_script(get_script(),
-                                                sol::script_default_on_error);
+        sol::error err = protected_result;
 
-        if (!protected_result.valid())
-        {
-            sol::error err = protected_result;
-            throw ErrorAtIndex(cat("Script execution error: ", err.what()), index);
-        }
+        auto msg = cat("Script execution error: ", err.what());
 
-        copy_used_variables_from_lua_to_context(lua, context);
-
-        sol::optional<bool> opt_result = protected_result;
-
-        if (opt_result)
-            result = *opt_result;
-    }
-    catch (const sol::error& e)
-    {
-        std::string msg = cat("Script execution error: ", e.what());
-
-        send_message(comm, Message::Type::step_stopped_with_error, msg,
-            Clock::now(), index);
+        send_message(comm, Message::Type::step_stopped_with_error, msg, Clock::now(),
+                     index);
 
         throw ErrorAtIndex(msg, index);
     }
+
+    copy_used_variables_from_lua_to_context(lua, context);
+
+    sol::optional<bool> opt_result = protected_result;
+
+    const bool result = opt_result.value_or(false);
 
     send_message(comm, Message::Type::step_stopped,
         cat("Step finished (logical result: ", result ? "true" : "false", ')'),

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -123,6 +123,7 @@ TEST_CASE("Executor: Run a sequence asynchronously", "[Executor]")
 TEST_CASE("Executor: Run a failing sequence asynchronously", "[Executor]")
 {
     Context context;
+    context.log_error_function = nullptr;
 
     Step step(Step::type_action);
     step.set_script("not valid LUA");
@@ -280,6 +281,8 @@ TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
     "[Executor]")
 {
     Context ctx;
+    ctx.log_error_function = nullptr;
+
     Sequence seq{ "test_sequence" };
 
     Step step_while{Step::type_while};
@@ -351,7 +354,8 @@ auto lua_testfun(sol::this_state s) -> sol::object
 
 TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
 {
-    Context ctx{ };
+    Context ctx;
+    ctx.log_error_function = nullptr;
 
     ctx.lua_init_function = [](sol::state& s) {
         s.set_function("testfun", &lua_testfun);

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -357,7 +357,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
         s.set_function("testfun", &lua_testfun);
     };
 
-    Sequence seq{ };
+    Sequence seq{ "Test" };
     Step step{ Step::type_action };
     step.set_script("a = testfun()");
 


### PR DESCRIPTION
This MR changes the definition of the LUAI_TRY macro to allow the correct reporting of C++ exceptions from user code inside Lua. It also includes a unit test by Fini for checking that.
    
**[why]**
We have a fundamental problem with exceptions in Lua and Sol. Our C++-compiled Lua throws "lua_longjmp*" as C++ exceptions for its internal error handling (as opposed to a C-compiled Lua that would use longjmp, with even worse side effects). Unfortunately, it catches its own exceptions with a "catch(...)".
    
Sol2 knows two modes of operation: With SOL_EXCEPTIONS_SAFE_PROPAGATION == 1, it assumes that user exceptions can safely bubble through the Lua engine and does not catch or handle them. In this case, Lua's "catch(...)" statement, however, will accidentally catch these user exceptions and report them in a weird way (as unrecognized exceptions, essentially).
    
With SOL_EXCEPTIONS_SAFE_PROPAGATION == 0, Sol2 puts its own try ... catch(...) around user C++ functions. User exceptions are then reported as expected, but unfortunately this also causes Sol2 to catch Lua-internal "lua_longjmp*" exceptions, which suppresses the correct reporting from lua_error().
    
**[how]**
Redefine the LUAI_TRY macro in luaconf.h. Originally, it is:
```
try { a } catch(...) { if ((c)->status == 0) (c)->status = -1; }
```    
We replace it by:
```    
try { a } catch(lua_longjmp*) { if ((c)->status == 0) (c)->status = -1; }
```    
We also have to define LUAI_UAI_THROW(L,c) and luai_jmpbuf because of the way these macros are set in the code. But there   are no functional changes here.

Fixes #4 