### PR TITLE
Ban a sequence without a name

### DIFF
--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -86,6 +86,7 @@ public:
     /**
      * Construct a Sequence with a descriptive name.
      * The label should describe the function of the sequence clearly and concisely.
+     * Leading and trailing whitespaces will be removed.
      *
      * \param label descriptive and expressive label.
      *
@@ -287,6 +288,7 @@ public:
 
     /**
      * Inject or modify with a new label. The label should not be empty.
+     * Leading and trailing whitespaces will be removed.
      *
      * \param new_label descriptive and expressive label.
      *
@@ -483,8 +485,14 @@ private:
     bool is_running_{false};
 
 
-    /// Check that the given description is valid. If not then throws a task::Error.
-    void check_label(gul14::string_view label);
+    /**
+     * Check that the given description is valid. If not then throws a task::Error. It
+     * will at first remove leading and trailing whitespaces.
+     *
+     * \param label checking label
+     * \return the checked label
+     */
+    std::string trim_and_check_label(gul14::string_view label);
 
     /**
      * Check the sequence for syntactic consistency and throw an exception if an error is

--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -83,7 +83,7 @@ public:
      * Construct a Sequence with a descriptive name.
      * The label should describe the function of the sequence clearly and concisely.
      *
-     * \param label [IN] descriptive and clear label.
+     * \param label descriptive and expressive label.
      *
      * \exception Error is thrown if the label is empty or if its length exceeds
      *            max_label_length characters.
@@ -280,6 +280,20 @@ public:
      * @returns a descriptive name for the sequence.
      */
     const std::string& get_label() const noexcept { return label_; }
+
+    /**
+     * Inject or modify with a new label. The label should not be empty.
+     *
+     * \param new_label descriptive and expressive label.
+     *
+     * \exception Error is thrown if the label is empty or if its length exceeds
+     *            max_label_length characters.
+     */
+    void set_label(gul14::string_view new_label)
+    {
+        check_label(new_label);
+        label_.assign(new_label.data(), new_label.size());
+    }
 
     /**
      * Insert the given \a Step before of the constant iterator into Sequence.

--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -86,7 +86,7 @@ public:
     /**
      * Construct a Sequence with a descriptive name.
      * The label should describe the function of the sequence clearly and concisely.
-     * Leading and trailing whitespaces will be removed.
+     * The label must not be empty. Leading and trailing whitespaces will be removed.
      *
      * \param label descriptive and expressive label.
      *
@@ -287,7 +287,7 @@ public:
     const std::string& get_label() const noexcept { return label_; }
 
     /**
-     * Inject or modify with a new label. The label should not be empty.
+     * Inject or modify with a new label. The label must not be empty.
      * Leading and trailing whitespaces will be removed.
      *
      * \param new_label descriptive and expressive label.

--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -289,11 +289,7 @@ public:
      * \exception Error is thrown if the label is empty or if its length exceeds
      *            max_label_length characters.
      */
-    void set_label(gul14::string_view new_label)
-    {
-        check_label(new_label);
-        label_.assign(new_label.data(), new_label.size());
-    }
+    void set_label(gul14::string_view new_label);
 
     /**
      * Insert the given \a Step before of the constant iterator into Sequence.

--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -77,6 +77,7 @@ public:
     using ConstIterator = std::vector<Step>::const_iterator;
     using ConstReverseIterator = std::vector<Step>::const_reverse_iterator;
 
+    /// Max number of bytes of a Sequence label.
     static constexpr std::size_t max_label_length = 128;
 
     /**
@@ -86,7 +87,7 @@ public:
      * \param label descriptive and expressive label.
      *
      * \exception Error is thrown if the label is empty or if its length exceeds
-     *            max_label_length characters.
+     *            max_label_length bytes.
      */
     explicit Sequence(gul14::string_view label);
 
@@ -287,7 +288,7 @@ public:
      * \param new_label descriptive and expressive label.
      *
      * \exception Error is thrown if the label is empty or if its length exceeds
-     *            max_label_length characters.
+     *            max_label_length bytes.
      */
     void set_label(gul14::string_view new_label);
 

--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -71,10 +71,13 @@ namespace task {
 class Sequence
 {
 public:
-    /// Abbreviation for steps.
+    /// Alias for step type.
     using SizeType = std::uint16_t;
+    /// Alias for a vector iterator.
     using Iterator = std::vector<Step>::iterator;
+    /// Alias for a constant vector iterator.
     using ConstIterator = std::vector<Step>::const_iterator;
+    /// Alias for a constant reverse vector iterator.
     using ConstReverseIterator = std::vector<Step>::const_reverse_iterator;
 
     /// Max number of bytes of a Sequence label.

--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -88,7 +88,7 @@ public:
      * \exception Error is thrown if the label is empty or if its length exceeds
      *            max_label_length characters.
      */
-    explicit Sequence(gul14::string_view label = "anonymous");
+    explicit Sequence(gul14::string_view label);
 
     /**
      * Assign a Step to the sequence entry at the given position.

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -26,6 +26,7 @@
 #include <gul14/SmallVector.h>
 #include <gul14/string_view.h>
 #include <gul14/substring_checks.h>
+#include <gul14/trim.h>
 
 #include "internals.h"
 #include "taskomat/Error.h"
@@ -66,8 +67,7 @@ Sequence::Sequence(gul14::string_view label)
 
 void Sequence::set_label(gul14::string_view new_label)
 {
-    check_label(new_label);
-    label_.assign(new_label.data(), new_label.size());
+    label_= trim_and_check_label(new_label);
 }
 
 void Sequence::assign(Sequence::ConstIterator iter, const Step& step)
@@ -86,16 +86,20 @@ void Sequence::assign(Sequence::ConstIterator iter, Step&& step)
     enforce_invariants();
 }
 
-void Sequence::check_label(gul14::string_view label)
+std::string Sequence::trim_and_check_label(gul14::string_view label)
 {
-    if (label.empty())
+    auto converted_label = gul14::trim(label);
+
+    if (converted_label.empty())
         throw Error("Sequence label may not be empty");
 
-    if (label.size() > max_label_length)
+    if (converted_label.size() > max_label_length)
     {
-        throw Error(cat("Label \"", label, "\" is too long (>", max_label_length,
-                        " bytes)"));
+        throw Error(cat("Label \"", converted_label, "\" is too long (>", max_label_length,
+                    " bytes)"));
     }
+
+    return converted_label;
 }
 
 void Sequence::check_syntax() const

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -61,8 +61,7 @@ find_end_of_indented_block(IteratorT begin, IteratorT end, short min_indentation
 
 Sequence::Sequence(gul14::string_view label)
 {
-    check_label(label);
-    label_.assign(label.data(), label.size());
+    set_label(label);git co
 }
 
 void Sequence::set_label(gul14::string_view new_label)

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -94,7 +94,7 @@ void Sequence::check_label(gul14::string_view label)
     if (label.size() > max_label_length)
     {
         throw Error(cat("Label \"", label, "\" is too long (>", max_label_length,
-                        " characters)"));
+                        " bytes)"));
     }
 }
 

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -65,6 +65,12 @@ Sequence::Sequence(gul14::string_view label)
     label_.assign(label.data(), label.size());
 }
 
+void Sequence::set_label(gul14::string_view new_label)
+{
+    check_label(new_label);
+    label_.assign(new_label.data(), new_label.size());
+}
+
 void Sequence::assign(Sequence::ConstIterator iter, const Step& step)
 {
     throw_if_running();

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -61,7 +61,7 @@ find_end_of_indented_block(IteratorT begin, IteratorT end, short min_indentation
 
 Sequence::Sequence(gul14::string_view label)
 {
-    set_label(label);git co
+    set_label(label);
 }
 
 void Sequence::set_label(gul14::string_view new_label)

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -63,7 +63,7 @@ TEST_CASE("Executor: Run a sequence asynchronously", "[Executor]")
     Step step(Step::type_action);
     step.set_script("sleep(0.02)");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step));
     REQUIRE(sequence.get_error_message() == "");
 
@@ -126,7 +126,7 @@ TEST_CASE("Executor: Run a failing sequence asynchronously", "[Executor]")
     Step step(Step::type_action);
     step.set_script("not valid LUA");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step));
     REQUIRE(sequence.get_error_message() == "");
 
@@ -164,7 +164,7 @@ TEST_CASE("Executor: cancel() within LUA sleep()", "[Executor]")
     Step step(Step::type_action);
     step.set_script("sleep(2)");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step));
 
     Executor executor;
@@ -214,7 +214,7 @@ TEST_CASE("Executor: cancel() within pcalls and CATCH blocks", "[Executor]")
         )");
     Step step_catch{ Step::type_catch };
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step_while));  // while
     sequence.push_back(std::move(step_try));    //   try
     sequence.push_back(std::move(step_action)); //     action: infinite loop
@@ -266,7 +266,7 @@ TEST_CASE("Executor: Redirection of print() output", "[Executor]")
     Step step( Step::type_action );
     step.set_script("print('Mary had', 3, 'little lambs.')");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step));
 
     Executor executor;
@@ -283,7 +283,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
     "[Executor]")
 {
     Context ctx;
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
 
     Step step_while{Step::type_while};
     Step step_increment{Step::type_action};

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -62,8 +62,8 @@ TEST_CASE("Sequence: get and set sequence label", "[Sequence]")
     s.set_label("modified_test_sequence");
     REQUIRE(s.get_label() == "modified_test_sequence");
 
-    REQUIRE_THROWS_AS(s.set_label(std::string(Sequence::max_label_length + 1, 'a'))
-        , Error);
+    REQUIRE_THROWS_AS(s.set_label(std::string(Sequence::max_label_length + 1, 'a')),
+        Error);
     REQUIRE_THROWS_AS(s.set_label(""), Error);
     REQUIRE_NOTHROW(s.set_label(std::string(Sequence::max_label_length, 'c')));
 }

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -39,6 +39,15 @@ TEST_CASE("Sequence: Constructor with too long descriptive name", "[Sequence]")
     REQUIRE_NOTHROW(Sequence(std::string(Sequence::max_label_length, 'c')));
 }
 
+TEST_CASE("Sequence: Construct an empty Sequence", "[Sequence]")
+{
+    Sequence s{ "test_sequence" };
+    REQUIRE(s.size() == 0);
+    REQUIRE(s.empty());
+    REQUIRE(s.begin() == s.end());
+    REQUIRE(s.cbegin() == s.cend());
+}
+
 TEST_CASE("Sequence: assign()", "[Sequence]")
 {
     Sequence seq{ "test_sequence" };

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -28,22 +28,54 @@
 using namespace task;
 using namespace std::literals;
 
-TEST_CASE("Sequence: Constructor without descriptive name", "[Sequence]")
+TEST_CASE("Sequence: Constructor without descriptive label", "[Sequence]")
 {
     REQUIRE_THROWS_AS(Sequence{ "" }, Error);
+    REQUIRE_THROWS_AS(Sequence{ " \t\v\n\r\f" }, Error);
 }
 
-TEST_CASE("Sequence: Constructor with too long descriptive name", "[Sequence]")
+TEST_CASE("Sequence: Constructor with descriptive label", "[Sequence]")
 {
     // label is to many characters -> throws Error
     REQUIRE_THROWS_AS(Sequence{ std::string(Sequence::max_label_length + 1, 'c') },
         Error);
-    // empty label -> throws Error
-    REQUIRE_THROWS_AS(Sequence{ "" } , Error);
     // minimum label length with one character
     REQUIRE_NOTHROW(Sequence{ "S" });
     // label length with all characters filled
     REQUIRE_NOTHROW(Sequence{ std::string(Sequence::max_label_length, 'c') });
+}
+
+TEST_CASE("Sequence: Constructor with get label", "[Sequence]")
+{
+    SECTION("label with leading blanks")
+    {
+        Sequence seq{ " test_sequence" };
+        REQUIRE(seq.get_label() == "test_sequence" );
+    }
+
+    SECTION("label with trailing blanks")
+    {
+        Sequence seq{ "test_sequence " };
+        REQUIRE(seq.get_label() == "test_sequence" );
+    }
+
+    SECTION("label with leading tab")
+    {
+        Sequence seq{ "\ttest_sequence" };
+        REQUIRE(seq.get_label() == "test_sequence" );
+    }
+
+    SECTION("label with trailing tab")
+    {
+        Sequence seq{ "test_sequence\t" };
+        REQUIRE(seq.get_label() == "test_sequence" );
+    }
+
+    SECTION("label surrounded with multiple whitespaces")
+    {
+        Sequence seq{ " \t\r\n\v\ftest_sequence \r\t\v\f\n" };
+        REQUIRE(seq.get_label() == "test_sequence" );
+    }
 }
 
 TEST_CASE("Sequence: Construct an empty Sequence", "[Sequence]")

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -35,7 +35,13 @@ TEST_CASE("Sequence: Constructor without descriptive name", "[Sequence]")
 
 TEST_CASE("Sequence: Constructor with too long descriptive name", "[Sequence]")
 {
+    // label is to many characters -> throws Error
     REQUIRE_THROWS_AS(Sequence(std::string(Sequence::max_label_length + 1, 'c')), Error);
+    // empty label -> throws Error
+    REQUIRE_THROWS_AS(Sequence(""), Error);
+    // minimum label length with one character
+    REQUIRE_NOTHROW(Sequence("S"));
+    // label length with all characters filled
     REQUIRE_NOTHROW(Sequence(std::string(Sequence::max_label_length, 'c')));
 }
 

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -58,10 +58,14 @@ TEST_CASE("Sequence: get and set sequence label", "[Sequence]")
 {
     Sequence s{ "test_sequence" };
     REQUIRE(s.get_label() == "test_sequence");
+
     s.set_label("modified_test_sequence");
     REQUIRE(s.get_label() == "modified_test_sequence");
+
     REQUIRE_THROWS_AS(s.set_label(std::string(Sequence::max_label_length + 1, 'a'))
         , Error);
+    REQUIRE_THROWS_AS(s.set_label(""), Error);
+    REQUIRE_NOTHROW(s.set_label(std::string(Sequence::max_label_length, 'c')));
 }
 
 TEST_CASE("Sequence: assign()", "[Sequence]")

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -30,19 +30,20 @@ using namespace std::literals;
 
 TEST_CASE("Sequence: Constructor without descriptive name", "[Sequence]")
 {
-    REQUIRE_THROWS_AS(Sequence(""), Error);
+    REQUIRE_THROWS_AS(Sequence{ "" }, Error);
 }
 
 TEST_CASE("Sequence: Constructor with too long descriptive name", "[Sequence]")
 {
     // label is to many characters -> throws Error
-    REQUIRE_THROWS_AS(Sequence(std::string(Sequence::max_label_length + 1, 'c')), Error);
+    REQUIRE_THROWS_AS(Sequence{ std::string(Sequence::max_label_length + 1, 'c') },
+        Error);
     // empty label -> throws Error
-    REQUIRE_THROWS_AS(Sequence(""), Error);
+    REQUIRE_THROWS_AS(Sequence{ "" } , Error);
     // minimum label length with one character
-    REQUIRE_NOTHROW(Sequence("S"));
+    REQUIRE_NOTHROW(Sequence{ "S" });
     // label length with all characters filled
-    REQUIRE_NOTHROW(Sequence(std::string(Sequence::max_label_length, 'c')));
+    REQUIRE_NOTHROW(Sequence{ std::string(Sequence::max_label_length, 'c') });
 }
 
 TEST_CASE("Sequence: Construct an empty Sequence", "[Sequence]")

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -28,16 +28,6 @@
 using namespace task;
 using namespace std::literals;
 
-TEST_CASE("Sequence: Construct empty sequence", "[Sequence]")
-{
-    Sequence seq;
-    REQUIRE(seq.empty());
-    REQUIRE(seq.size() == 0);
-
-    static_assert(std::is_default_constructible<Sequence>::value,
-        "Sequence is_default_constructible");
-}
-
 TEST_CASE("Sequence: Constructor without descriptive name", "[Sequence]")
 {
     REQUIRE_THROWS_AS(Sequence(""), Error);
@@ -51,7 +41,7 @@ TEST_CASE("Sequence: Constructor with too long descriptive name", "[Sequence]")
 
 TEST_CASE("Sequence: assign()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(Step{Step::type_action});
     seq.push_back(Step{Step::type_action});
     seq.push_back(Step{Step::type_action});
@@ -80,7 +70,7 @@ TEST_CASE("Sequence: assign()", "[Sequence]")
 
 TEST_CASE("Sequence: empty()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     REQUIRE(seq.empty());
     seq.push_back(Step{});
     REQUIRE(seq.empty() == false);
@@ -88,7 +78,7 @@ TEST_CASE("Sequence: empty()", "[Sequence]")
 
 TEST_CASE("Sequence: erase()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(Step{Step::type_action});
     seq.push_back(Step{Step::type_while});
     seq.push_back(Step{Step::type_action});
@@ -161,7 +151,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
 
 TEST_CASE("Sequence: get_error_message()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     REQUIRE(seq.get_error_message() == "");
 
     seq.set_error_message("Test");
@@ -170,7 +160,7 @@ TEST_CASE("Sequence: get_error_message()", "[Sequence]")
 
 TEST_CASE("Sequence: insert()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(Step{Step::type_action});
     seq.push_back(Step{Step::type_action});
 
@@ -224,7 +214,7 @@ TEST_CASE("Sequence: is_running()", "[Sequence]")
     Step step1{ Step::type_action };
     step1.set_script("a = 10");
 
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(step1);
 
     REQUIRE(not seq.is_running());
@@ -248,7 +238,7 @@ TEST_CASE("Sequence: modify()", "[Sequence]")
     ori_step.set_script("a = 1");
     ori_step.set_time_of_last_execution(Clock::now());
 
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(Step{ Step::type_if });
     seq.push_back(ori_step);
     seq.push_back(Step{ Step::type_end });
@@ -309,7 +299,7 @@ TEST_CASE("Sequence: modify()", "[Sequence]")
 
 TEST_CASE("Sequence: pop_back()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(Step{});
     seq.push_back(Step{});
     REQUIRE(seq.empty() == false);
@@ -329,7 +319,7 @@ TEST_CASE("Sequence: pop_back()", "[Sequence]")
 
 TEST_CASE("Sequence: push_back()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
 
     SECTION("append lvalue Step")
     {
@@ -357,7 +347,7 @@ TEST_CASE("Sequence: push_back()", "[Sequence]")
 
 TEST_CASE("Sequence: set_error_message()", "[Sequence]")
 {
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
 
     seq.set_error_message("Test");
     REQUIRE(seq.get_error_message() == "Test");
@@ -376,7 +366,7 @@ TEST_CASE("Sequence: set_running()", "[Sequence]")
     step2.set_label("conditional");
     step2.set_script("return true");
 
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
     seq.push_back(step1);
 
     seq.set_running(true);
@@ -1189,7 +1179,7 @@ TEST_CASE("execute(): if-else sequence", "[Sequence]")
 
     step_if_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_action_if);
     sequence.push_back(step_else);
@@ -1258,7 +1248,7 @@ TEST_CASE("execute(): if-elseif sequence", "[Sequence]")
 
     step_if_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_if_action);
     sequence.push_back(step_elseif);
@@ -1346,7 +1336,7 @@ TEST_CASE("execute(): if-elseif-else sequence", "[Sequence]")
 
     step_if_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_if_action);
     sequence.push_back(step_elseif);
@@ -1436,7 +1426,7 @@ TEST_CASE("execute(): if-elseif-elseif sequence", "[Sequence]")
 
     step_if_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_if_action);
     sequence.push_back(step_elseif1);
@@ -1546,7 +1536,7 @@ TEST_CASE("execute(): if-elseif-elseif-else sequence", "[Sequence]")
 
     step_if_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_if_action);
     sequence.push_back(step_elseif1);
@@ -1634,7 +1624,7 @@ TEST_CASE("execute(): if-elseif-else-end sequence with empty blocks", "[Sequence
 
     step_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_elseif1);
     sequence.push_back(step_elseif2);
@@ -1722,7 +1712,7 @@ TEST_CASE("execute(): faulty if-else-elseif sequence", "[Sequence]")
 
     step_if_end.set_label("if: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_if);
     sequence.push_back(step_if_action);
     sequence.push_back(step_if_else);
@@ -1768,7 +1758,7 @@ TEST_CASE("execute(): while sequence", "[Sequence]")
 
     step_while_end.set_label("while: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_while);
     sequence.push_back(step_while_action);
     sequence.push_back(step_while_end);
@@ -1806,7 +1796,7 @@ TEST_CASE("execute(): empty while sequence", "[Sequence]")
 
     step_end.set_label("while: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_while);
     sequence.push_back(step_end);
 
@@ -1857,7 +1847,7 @@ TEST_CASE("execute(): try sequence with success", "[Sequence]")
 
     step_try_end.set_label("try: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_try);
     sequence.push_back(step_try_action);
     sequence.push_back(step_try_catch);
@@ -1914,7 +1904,7 @@ TEST_CASE("execute(): try sequence with fault", "[Sequence]")
 
     step_try_end.set_label("try: end");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_try);
     sequence.push_back(step_try_action1);
     sequence.push_back(step_try_action2);
@@ -2001,7 +1991,7 @@ TEST_CASE("execute(): complex try sequence with nested fault condition",
 
     step_10.set_label("try [end]");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_00);
     sequence.push_back(step_01);
     sequence.push_back(step_02);
@@ -2071,7 +2061,7 @@ TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
 
     step_06.set_label("try [end]");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_00);
     sequence.push_back(step_01);
     sequence.push_back(step_02);
@@ -2165,7 +2155,7 @@ TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
 
     step_11.set_label("try [end]");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_00);
     sequence.push_back(step_01);
     sequence.push_back(step_02);
@@ -2392,7 +2382,7 @@ TEST_CASE("execute(): complex sequence", "[Sequence]")
 
     step_31.set_label("while [end]");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     // 32 steps
     sequence.push_back(step_00);
 
@@ -2633,7 +2623,7 @@ TEST_CASE("execute(): complex sequence with misplaced if", "[Sequence]")
 
     Step step_31{Step::type_end};
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     // 32 steps
     sequence.push_back(step_00);
 
@@ -2701,7 +2691,7 @@ TEST_CASE("execute_sequence(): Messages", "[execute_sequence]")
     step2.set_used_context_variable_names(VariableNames{ "a" });
     step2.set_script("a = a + 2");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step1));
     sequence.push_back(std::move(step2));
 
@@ -2805,7 +2795,7 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     step_post.set_used_context_variable_names(VariableNames{"a", "b"});
     step_post.set_script("b = 1");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_pre); // a = 1
     sequence.push_back(step_if); // IF a == 1
     sequence.push_back(step_if_action); // a = 2
@@ -2854,7 +2844,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     step2.set_used_context_variable_names(VariableNames{"a"});
     step2.set_script("a = a + 1");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step1);
     sequence.push_back(step2);
     sequence.push_back(step2);
@@ -2954,7 +2944,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
 
     SECTION("Second step disabled")
     {
-        Sequence sequence;
+        Sequence sequence{ "test_sequence" };
         sequence.push_back(step_pre); // a = 1
         sequence.push_back(copy_and_disable(step_if)); // IF a == 1
         sequence.push_back(step_if_action); // a = 2
@@ -2981,7 +2971,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
 
     SECTION("Third step disabled")
     {
-        Sequence sequence;
+        Sequence sequence{ "test_sequence" };
         sequence.push_back(step_pre); // a = 1
         sequence.push_back(step_if); // IF a == 1
         sequence.push_back(copy_and_disable(step_if_action)); // a = 2
@@ -3008,7 +2998,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
 
     SECTION("Fourth step disabled")
     {
-        Sequence sequence;
+        Sequence sequence{ "test_sequence" };
         sequence.push_back(step_pre); // a = 1
         sequence.push_back(step_if); // IF a == 1
         sequence.push_back(step_if_action); // a = 2
@@ -3092,7 +3082,7 @@ TEST_CASE("execute(): disable 'invariant' (afterwards)", "[Sequence]")
     step_post.set_used_context_variable_names(VariableNames{"a", "b"});
     step_post.set_script("b = 1");
 
-    Sequence sequence;
+    Sequence sequence{ "test_sequence" };
     sequence.push_back(step_pre); // a = 1
     sequence.push_back(step_if); // IF a == 1
     sequence.push_back(step_if_action); // a = 2
@@ -3204,7 +3194,7 @@ TEST_CASE("execute(): disable 'invariant' (complex)", "[Sequence]")
     // 10    END
     // 11    ACTION
 
-    Sequence s{ };
+    Sequence s{ "test_sequence" };
     s.push_back(Step{ Step::type_action });
     s.push_back(Step{ Step::type_if });
     s.push_back(Step{ Step::type_action });
@@ -3314,7 +3304,7 @@ TEST_CASE("execute(): Disable + re-enable action inside while loop", "[Sequence]
     //  1   ACTION
     //  2 END
 
-    Sequence s{ };
+    Sequence s{ "test_sequence" };
     s.push_back(Step{ Step::type_while });
     s.push_back(Step{ Step::type_action });
     s.push_back(Step{ Step::type_end });
@@ -3343,7 +3333,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
     auto& queue = comm.queue_;
 
     Context ctx;
-    Sequence seq;
+    Sequence seq{ "test_sequence" };
 
     Step step_while{Step::type_while};
     Step step_increment{Step::type_action};

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -48,6 +48,16 @@ TEST_CASE("Sequence: Construct an empty Sequence", "[Sequence]")
     REQUIRE(s.cbegin() == s.cend());
 }
 
+TEST_CASE("Sequence: get and set sequence label", "[Sequence]")
+{
+    Sequence s{ "test_sequence" };
+    REQUIRE(s.get_label() == "test_sequence");
+    s.set_label("modified_test_sequence");
+    REQUIRE(s.get_label() == "modified_test_sequence");
+    REQUIRE_THROWS_AS(s.set_label(std::string(Sequence::max_label_length + 1, 'a'))
+        , Error);
+}
+
 TEST_CASE("Sequence: assign()", "[Sequence]")
 {
     Sequence seq{ "test_sequence" };


### PR DESCRIPTION
[why]
A sequence must have a name to be recognised by the users. The previous anonymous sequence is therefore forbidden.

[how]
In the previous constructor you can create a `Sequence` without any name. The sequence then indirectly uses `anonymous` as its name. In practice this can be cumbersome by the users who cannot distinguish between sequence names. Therefore the user is forced to give a sequence a reliable and expressive name.

Fixes: #7 

_Edit: Add link to issue_