### PR TITLE
Fix failing Executor test

### DIFF
--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -124,7 +124,7 @@ TEST_CASE("Executor: Run a failing sequence asynchronously", "[Executor]")
     Context context;
 
     Step step(Step::type_action);
-    step.set_script("not valid LUA");
+    step.set_script("sleep(0.5)\nnot valid LUA");
 
     Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step));


### PR DESCRIPTION
[why]
Testing the Executor fails on Github CI.

The reason seems to be:
- We want to test failing a script that consists just of a syntax error
- Script is started
- Script running is asserted
- Now the test fails

If the script fails faster than we can check the running state that must fail.

[how]
To have enough time to assert the running script the script first waits some time and only afterwards presents a syntax error.

Fixes: #19