### PR TITLE
Fix failing Executor test by not testing un-guaranteed conditions

### DIFF
--- a/include/taskomat/Sequence.h
+++ b/include/taskomat/Sequence.h
@@ -245,8 +245,7 @@ public:
      * given by steps such as WHILE, IF, TRY, and so on. It returns when the sequence is
      * finished or has stopped with an error.
      *
-     * During execute(), is_running() returns true (which can only be observed by internal
-     * functions or LUA callbacks). Afterwards, it returns false.
+     * During execute(), is_running() returns true to internal functions or LUA callbacks.
      *
      * \param context A context for storing variables that can be exchanged between
      *                different steps. The context may also contain a LUA init function

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -135,14 +135,10 @@ TEST_CASE("Executor: Run a failing sequence asynchronously", "[Executor]")
     Executor executor;
     executor.run_asynchronously(sequence, context);
 
-    // Error message must have been cleared
-    REQUIRE(sequence.get_error_message() == "");
-
-    // As long as the thread is running, update() and is_busy() must return true,
-    // and the sequence must signalize is_running().
-    REQUIRE(executor.is_busy() == true);
-    REQUIRE(executor.update(sequence) == true);
+    // The sequence must signalize is_running() == true and an empty error message at
+    // least until the first call to is_busy() or update().
     REQUIRE(sequence.is_running() == true);
+    REQUIRE(sequence.get_error_message() == "");
 
     // Process messages as long as the thread is running
     while (executor.update(sequence))


### PR DESCRIPTION
**[why]**
As shown in #19, `Executor::is_busy()` may return false almost directly after a call to `Executor::run_asynchronously()`, depending on the load of the system.

**[how]**
Do not test for conditions that are not logically guaranteed.

Fixes: #19 
