### PR TITLE
Step: Resync variables from state to context also on errors

### DIFF
--- a/src/Step.cc
+++ b/src/Step.cc
@@ -119,10 +119,11 @@ bool Step::execute(Context& context, CommChannel* comm, StepIndex index)
         context.lua_init_function(lua);
 
     install_timeout_and_termination_request_hook(lua, now, get_timeout(), index, comm);
-
     copy_used_variables_from_context_to_lua(context, lua);
 
     auto result_or_error = execute_lua_script_safely(lua, get_script());
+
+    copy_used_variables_from_lua_to_context(lua, context);
     bool result_bool = false;
 
     if (std::holds_alternative<sol::object>(result_or_error))
@@ -158,8 +159,6 @@ bool Step::execute(Context& context, CommChannel* comm, StepIndex index)
                      index);
         throw ErrorAtIndex(msg, index);
     }
-
-    copy_used_variables_from_lua_to_context(lua, context);
 
     send_message(comm, Message::Type::step_stopped,
         requires_bool_return_value(get_type())

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -563,7 +563,7 @@ TEST_CASE("execute(): Immediate termination", "[Step]")
 
     REQUIRE_THROWS_AS(step.execute(context, &comm, 0), Error);
     REQUIRE(comm.immediate_termination_requested_);
-    REQUIRE(std::get<long long>(context.variables["a"]) == 0LL);
+    REQUIRE(std::get<long long>(context.variables["a"]) == -1LL);
 }
 
 TEST_CASE("execute(): Setting 'last executed' timestamp", "[Step]")


### PR DESCRIPTION
**[why]**
If a Step has an error (syntax or runtime), or aborts changed variables from the context are not synced back to the context.

This makes it impossible to use the variables that are handed over from Step to Step in a Sequence to keep information stored into them if the Step that stored the information errors out.

**[how]**
Copy the context variables after the script returned from state to context always. Regardless if the script errored out or not.

Fixes: #24 

-----

Also dropped some empty lines; that code there is _very_ verbose and the length of the function names border on Koerperverletzung ;-D