### PR TITLE
Step: Use correct type to access variables in state

### DIFF
--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -32,6 +32,10 @@
 #include "taskolib/CommChannel.h"
 #include "taskolib/Context.h"
 
+// Check that the lua lib has been build with the expected types
+static_assert(std::is_same<LUA_NUMBER, double>::value, "Unexpected Lua-internal floating point type");
+static_assert(std::is_same<LUA_INTEGER, long long>::value, "Unexpected Lua-internal integer type");
+
 namespace task {
 
 // Abort the execution of the script by raising a LUA error with the given error message.


### PR DESCRIPTION
**[why]**
It works now on our platform, but variable access could break.

**[how]**
The concrete types of the variables in the state are not actually defined to be some C++ type but have their own alias. Use that.

----

I fear plain `long long` and `double` has been used in a lot more places in the codebase, where it should have been `LUA_INTEGER` and `LUA_NUMBER`.

Came up when creating #28, because that uses these functions.