### PR TITLE
Better exception handling with Sol 3.3.0

### DIFF
--- a/include/taskolib/Step.h
+++ b/include/taskolib/Step.h
@@ -82,6 +82,11 @@ public:
      * 5. Selected variables are exported from the runtime environment back into the
      *    context.
      *
+     * Certain step types (IF, ELSEIF, WHILE) require the script to return a boolean
+     * value. Not returning a value or returning a different type is considered an error.
+     * Conversely, the other step types (ACTION etc.) do not allow returning values from
+     * the script, with the exception of nil.
+     *
      * \param context       The context to be used for executing the step
      * \param comm_channel  Pointer to a communication channel; If this is null, messaging
      *                      is disabled and there is no way to stop the execution.
@@ -94,15 +99,15 @@ public:
      *                        been stopped due to an error condition
      * \param index         Index of the step in its parent Sequence.
      *
-     * \returns true if the script returns a value that evaluates as true in the scripting
-     *          language, or false otherwise (even in the case that the script returns no
-     *          value at all).
+     * \return If the step type requires a boolean return value (IF, ELSEIF, WHILE), this
+     *         function returns the return value of the script. For other step types
+     *         (ACTION etc.), it returns false.
      *
      * \exception Error or ErrorAtIndex is thrown if the script cannot be started, if
-     *            there is a Lua error during execution, if a timeout is encountered, or
-     *            if termination has been requested via the communication channel. If the
-     *            Lua script explicitly terminates by a call to the custom Lua function
-     *            \a terminate_sequence(), the step is set to not running and throws.
+     *            there is a Lua error during execution, if the script has an
+     *            inappropriate return value for the step type (see above), if a timeout
+     *            is encountered, or if termination has been requested via the
+     *            communication channel or explicitly by the script.
      */
     bool execute(Context& context, CommChannel* comm_channel, StepIndex index);
 
@@ -118,17 +123,22 @@ public:
      * 5. Selected variables are exported from the runtime environment back into the
      *    context.
      *
-     * \param context  The context to be used for executing the step
+     * Certain step types (IF, ELSEIF, WHILE) require the script to return a boolean
+     * value. Not returning a value or returning a different type is considered an error.
+     * Conversely, the other step types (ACTION etc.) do not allow returning values from
+     * the script, with the exception of nil.
      *
-     * \returns true if the script returns a value that evaluates as true in the scripting
-     *          language, or false otherwise (even in the case that the script returns no
-     *          value at all).
+     * \param context       The context to be used for executing the step
      *
-     * \exception Error or ErrorAtIndex is thrown if the script cannot be started or if
-     *            it raises an error during execution (for ErrorAtIndex, the index is
-     *            assumed as zero). If the Lua script explicitly terminates by a call to
-     *            the custom Lua function \a terminate_sequence(), the step is set to not
-     *            running and throws.
+     * \return If the step type requires a boolean return value (IF, ELSEIF, WHILE), this
+     *         function returns the return value of the script. For other step types
+     *         (ACTION etc.), it returns false.
+     *
+     * \exception Error or ErrorAtIndex is thrown if the script cannot be started, if
+     *            there is a Lua error during execution, if the script has an
+     *            inappropriate return value for the step type (see above), if a timeout
+     *            is encountered, or if termination has been requested explicitly by the
+     *            script.
      */
     bool execute(Context& context)
     {
@@ -309,6 +319,9 @@ private:
 
 /// Return a lower-case name for a step type ("action", "if", "end").
 std::string to_string(Step::Type type);
+
+/// Determine if a certain step type requires a boolean return value from the script.
+bool requires_bool_return_value(Step::Type step_type) noexcept;
 
 } // namespace task
 

--- a/include/taskolib/lua/luaconf.h
+++ b/include/taskolib/lua/luaconf.h
@@ -782,15 +782,5 @@
 ** without modifying the main part of the file.
 */
 
-#define LUAI_THROW(L,c) \
-	throw(c)
-
-#define LUAI_TRY(L,c,a) \
-	try { a } catch(lua_longjmp*) { if ((c)->status == 0) (c)->status = -1; }
-
-#define luai_jmpbuf \
-	int  /* dummy variable */
-
-
 #endif
 

--- a/include/taskolib/sol/sol/config.hpp
+++ b/include/taskolib/sol/sol/config.hpp
@@ -34,8 +34,8 @@ the build system, or the command line options of your compiler.
 // properly handles exceptions.
 #define SOL_USING_CXX_LUA 1
 
-// Tell Sol3 that our custom LUA build can safely propagate exceptions
-#define SOL_EXCEPTIONS_SAFE_PROPAGATION 1
+// Enable a trampoline for C/C++ functions injected into Lua (among other things)
+#define SOL_PROPAGATE_EXCEPTIONS 0
 
 // Tell Sol3 to make several checks so that we can actually differentiate integers from
 // floating-point numbers.

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ test_src = files(
     'tests/test_Executor.cc',
     #'tests/test_format.cc' needs fmt{} library
     'tests/test_LockedQueue.cc',
+    'tests/test_lua_details.cc',
     'tests/test_main.cc',
     'tests/test_Message.cc',
     'tests/test_Sequence.cc',

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -111,6 +111,31 @@ void check_script_timeout(lua_State* lua_state)
     }
 }
 
+std::variant<sol::object, std::string>
+execute_lua_script_safely(sol::state& lua, sol::string_view script)
+{
+    try
+    {
+        auto protected_result = lua.safe_script(script, sol::script_pass_on_error);
+
+        if (!protected_result.valid())
+        {
+            sol::error err = protected_result;
+            return cat("Script execution error: ", err.what());
+        }
+
+        return static_cast<sol::object>(protected_result);
+    }
+    catch(const std::exception& e)
+    {
+        return cat("Script execution error: ", e.what());
+    }
+    catch(...)
+    {
+        return std::string{ "Unknown C++ exception" };
+    }
+}
+
 CommChannel* get_comm_channel_ptr_from_registry(lua_State* lua_state)
 {
     sol::state_view lua(lua_state);

--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -28,6 +28,8 @@
 #include <chrono>
 #include <functional>
 #include <string>
+#include <variant>
+
 #include "sol/sol.hpp"
 #include "taskolib/CommChannel.h"
 #include "taskolib/Context.h"
@@ -43,6 +45,17 @@ void check_immediate_termination_request(lua_State* lua_state);
 
 // Check if the step timeout has expired and raise a LUA error if that is the case.
 void check_script_timeout(lua_State* lua_state);
+
+/**
+ * Execute a Lua script safely, intercepting all possible exceptions that may occur during
+ * its execution.
+ *
+ * This function returns a variant: If the Lua script finishes without error, it contains
+ * a sol::object representing the return value of the script. If a Lua error or C++
+ * exception occurs, the variant contains a string with an error message.
+ */
+std::variant<sol::object, std::string>
+execute_lua_script_safely(sol::state& lua, sol::string_view script);
 
 /**
  * Retrieve a pointer to the used CommChannel from the LUA registry.

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -358,8 +358,8 @@ TEST_CASE("execute(): C++ exceptions", "[Step]")
     {
         step.set_script("throw_logic_error(); a = 42");
 
-        // A C++ exception bubbles through the Lua execution callstack, but must be caught
-        // by Sol2, returned as a protected_function_result, and reported as a task::Error.
+        // Like a genuine Lua exception, a C++ exception must be reported as a
+        // task::ErrorAtIndex.
         REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
         REQUIRE(std::get<long long>(context.variables["a"]) == 0);
     }
@@ -368,21 +368,16 @@ TEST_CASE("execute(): C++ exceptions", "[Step]")
     {
         step.set_script("throw_weird_exception(); a = 42");
 
-        // A C++ exception bubbles through the Lua execution callstack, but must be caught
-        // by Sol2, returned as a protected_function_result, and reported as a task::Error.
         REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
         REQUIRE(std::get<long long>(context.variables["a"]) == 0);
     }
 
-    SECTION("C++ exceptions are not caught by pcall()")
+    SECTION("C++ exceptions are correctly caught by pcall()")
     {
         step.set_script("pcall(throw_logic_error); a = 42");
 
-        // A C++ exception bubbles through the Lua execution callstack and cannot be
-        // caught by pcall(). It must, however, be caught by Step::execute() and reported
-        // as a task::Error.
-        REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
-        REQUIRE(std::get<long long>(context.variables["a"]) == 0);
+        REQUIRE_NOTHROW(step.execute(context));
+        REQUIRE(std::get<long long>(context.variables["a"]) == 42LL);
     }
 }
 

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -273,32 +273,47 @@ TEST_CASE("execute(): Boolean return value from simple scripts", "[Step]")
     Context context;
     Step step;
 
-    SECTION("Empty step returns false")
-    {
+    SECTION("Empty step returns false") {
         REQUIRE(step.execute(context) == false);
     }
 
-    SECTION("'return true' returns true")
-    {
+    SECTION("'return true' returns true") {
         step.set_script("return true");
         REQUIRE(step.execute(context) == true);
     }
 
-    SECTION("'return false' returns false")
-    {
+    SECTION("'return false' returns false") {
         step.set_script("return true");
         REQUIRE(step.execute(context) == true);
     }
 
-    SECTION("'return nil' returns false")
-    {
+    SECTION("'return nil' returns false") {
         step.set_script("return nil");
         REQUIRE(step.execute(context) == false);
     }
 
-    SECTION("'return 42' returns true")
-    {
-        step.set_script("return true");
+    SECTION("'return 42' returns true") {
+        step.set_script("return 42");
+        REQUIRE(step.execute(context) == true);
+    }
+
+    SECTION("'return 0' returns false") {
+        step.set_script("return 0");
+        REQUIRE(step.execute(context) == false);
+    }
+
+    SECTION("'return 0.1' returns true") {
+        step.set_script("return 0.1");
+        REQUIRE(step.execute(context) == true);
+    }
+
+    SECTION("'return 0.0' returns false") {
+        step.set_script("return 0.0");
+        REQUIRE(step.execute(context) == false);
+    }
+
+    SECTION("\"return 'false'\" returns true (sic!)") {
+        step.set_script("return 'false'");
         REQUIRE(step.execute(context) == true);
     }
 }
@@ -372,7 +387,7 @@ TEST_CASE("execute(): C++ exceptions", "[Step]")
         REQUIRE(std::get<long long>(context.variables["a"]) == 0);
     }
 
-    SECTION("C++ exceptions are correctly caught by pcall()")
+    SECTION("C++ exceptions are converted to Lua errors and caught by pcall()")
     {
         step.set_script("pcall(throw_logic_error); a = 42");
 

--- a/tests/test_lua_details.cc
+++ b/tests/test_lua_details.cc
@@ -109,10 +109,10 @@ TEST_CASE("execute_lua_script_safely(): Lua exceptions", "[lua_details]")
     SECTION("Runtime error")
     {
         auto result_or_error = execute_lua_script_safely(
-            lua, "function boom(); error('pippo', 0); end; boom()");
+            lua, "function boom(); error('mindful' .. 'ness', 0); end; boom()");
         auto* msg = std::get_if<std::string>(&result_or_error);
         REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, StartsWith("Script execution error: pippo"));
+        REQUIRE_THAT(*msg, StartsWith("Script execution error: mindfulness"));
         // Lua adds a stack trace after this output. This is a somewhat brittle test,
         // but since we have control over our Lua version, we are sure to spot it if
         // the output format changes.
@@ -133,7 +133,7 @@ TEST_CASE("execute_lua_script_safely(): C++ exceptions", "[Step]")
     sol::state lua;
     open_safe_library_subset(lua); // for error() and pcall()
 
-    lua["throw_logic_error"] = []() { throw std::logic_error("pippo"); };
+    lua["throw_logic_error"] = []() { throw std::logic_error("red rabbit"); };
     lua["throw_weird_exception"] = []() { struct Weird{}; throw Weird{}; };
 
     SECTION("C++ standard exception are reported as errors with error message")
@@ -142,7 +142,7 @@ TEST_CASE("execute_lua_script_safely(): C++ exceptions", "[Step]")
             lua, "throw_logic_error()");
         auto* msg = std::get_if<std::string>(&result_or_error);
         REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, Contains("pippo"));
+        REQUIRE_THAT(*msg, Contains("red rabbit"));
     }
 
     SECTION("Nonstandard C++ exceptions are reported as errors")

--- a/tests/test_lua_details.cc
+++ b/tests/test_lua_details.cc
@@ -1,0 +1,174 @@
+/**
+ * \file   test_lua_details.cc
+ * \author Lars Froehlich
+ * \date   Created on October 28, 2022
+ * \brief  Test suite for Lua-related internal functions.
+ *
+ * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gul14/catch.h>
+#include <gul14/time_util.h>
+
+#include "../src/lua_details.h"
+
+using namespace std::literals;
+using namespace task;
+using namespace Catch::Matchers;
+
+TEST_CASE("execute_lua_script_safely(): Return values from simple scripts without errors",
+    "[lua_details]")
+{
+    sol::state lua;
+
+    SECTION("Empty script")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(*result == sol::nil);
+    }
+
+    SECTION("return nil")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "return nil");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(*result == sol::nil);
+    }
+
+    SECTION("return true")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "return true");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<bool>() == true);
+    }
+
+    SECTION("return false")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "return false");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<bool>() == false);
+    }
+
+    SECTION("return 42")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "return 42");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<int>() == 42);
+    }
+
+    SECTION("return 4.2")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "return 4.2");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<double>() == 4.2);
+    }
+
+    SECTION("return 'pippo'")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "return 'pippo'");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<std::string>() == "pippo");
+    }
+}
+
+TEST_CASE("execute_lua_script_safely(): Lua exceptions", "[lua_details]")
+{
+    sol::state lua;
+    open_safe_library_subset(lua); // for error() and pcall()
+
+    SECTION("Syntax error")
+    {
+        auto result_or_error = execute_lua_script_safely(lua, "not a lua program");
+        auto* msg = std::get_if<std::string>(&result_or_error);
+        REQUIRE(msg != nullptr);
+        REQUIRE(*msg != "");
+    }
+
+    SECTION("Runtime error")
+    {
+        auto result_or_error = execute_lua_script_safely(
+            lua, "function boom(); error('pippo', 0); end; boom()");
+        auto* msg = std::get_if<std::string>(&result_or_error);
+        REQUIRE(msg != nullptr);
+        REQUIRE_THAT(*msg, StartsWith("Script execution error: pippo"));
+        // Lua adds a stack trace after this output. This is a somewhat brittle test,
+        // but since we have control over our Lua version, we are sure to spot it if
+        // the output format changes.
+    }
+
+    SECTION("Runtime error, caught by pcall()")
+    {
+        auto result_or_error = execute_lua_script_safely(
+            lua, "function boom(); b = nil; b(); end; pcall(boom); return 42");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<int>() == 42);
+    }
+}
+
+TEST_CASE("execute_lua_script_safely(): C++ exceptions", "[Step]")
+{
+    sol::state lua;
+    open_safe_library_subset(lua); // for error() and pcall()
+
+    lua["throw_logic_error"] = []() { throw std::logic_error("pippo"); };
+    lua["throw_weird_exception"] = []() { struct Weird{}; throw Weird{}; };
+
+    SECTION("C++ standard exception are reported as errors with error message")
+    {
+        auto result_or_error = execute_lua_script_safely(
+            lua, "throw_logic_error()");
+        auto* msg = std::get_if<std::string>(&result_or_error);
+        REQUIRE(msg != nullptr);
+        REQUIRE_THAT(*msg, Contains("pippo"));
+    }
+
+    SECTION("Nonstandard C++ exceptions are reported as errors")
+    {
+        auto result_or_error = execute_lua_script_safely(
+            lua, "throw_weird_exception()");
+        auto* msg = std::get_if<std::string>(&result_or_error);
+        REQUIRE(msg != nullptr);
+        REQUIRE(*msg != "");
+    }
+
+    SECTION("Standard C++ exceptions are converted to Lua errors and caught by pcall()")
+    {
+        auto result_or_error = execute_lua_script_safely(
+            lua, "pcall(throw_logic_error); return 42");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<int>() == 42);
+    }
+
+    SECTION("Nonstandard C++ exceptions are converted to Lua errors and caught by pcall()")
+    {
+        auto result_or_error = execute_lua_script_safely(
+            lua, "pcall(throw_weird_error); return 42");
+        auto* result = std::get_if<sol::object>(&result_or_error);
+        REQUIRE(result != nullptr);
+        REQUIRE(result->as<int>() == 42);
+    }
+}


### PR DESCRIPTION
This is yet another take on exception handling, this time with the new Sol2 version 3.3.0 that Fini introduced. It finally allows us to treat C++ exceptions like Lua exceptions and intercept them with `pcall()`.

With Sol 3.3.0, there are new configuration macros that allow enabling C/C++ function call trampolines without breaking Lua's internal exception propagation mechanism. Hence, we no longer need to modify Lua's LUAI_CATCH macro, but can use the default one.
    
For enabling the trampoline, we use SOL_PROPAGATE_EXCEPTIONS == 0 instead of the old SOL_SAFE_EXCEPTION_PROPAGATION == 1.

There are a number of related changes and extended tests as well.