### PR TITLE
Test all headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,25 +69,6 @@ sources = files(
     'src/VariableName.cc',
 )
 
-# Test sources
-test_src = files(
-    'tests/test_CommChannel.cc',
-    'tests/test_Context.cc',
-    'tests/test_exceptions.cc',
-    'tests/test_Executor.cc',
-    #'tests/test_format.cc' needs fmt{} library
-    'tests/test_LockedQueue.cc',
-    'tests/test_lua_details.cc',
-    'tests/test_main.cc',
-    'tests/test_Message.cc',
-    'tests/test_Sequence.cc',
-    'tests/test_SequenceManager.cc',
-    'tests/test_serialize_sequence.cc',
-    'tests/test_Step.cc',
-    'tests/test_time_types.cc',
-    'tests/test_VariableName.cc',
-)
-
 
 ## Determine the version number
 
@@ -174,30 +155,7 @@ taskolib_dep = declare_dependency(
     dependencies : [ deps, gul_dep, ],
 )
 
-## Tests
-
-# The tests are executed in the build dir to avoid pollution of the git repository with
-# the test executable's output files
-test('all',
-    executable(meson.project_name() + '_test',
-        test_src,
-        dependencies : taskolib_dep,
-    ),
-    workdir : meson.current_build_dir(),
-    timeout : 10,
-)
-
-fmt_dep = dependency('fmt', required : false)
-if fmt_dep.found()
-    test('format',
-        executable(meson.project_name() + '_format_test',
-            [ 'tests/test_format.cc', 'tests/test_main.cc', ],
-            dependencies : [ taskolib_dep, dependency('fmt'), ],
-        ),
-        timeout : 10,
-    )
-endif
-
+subdir('tests')
 
 ## Examples
 

--- a/meson.build
+++ b/meson.build
@@ -27,26 +27,27 @@ sol_version = '3.3.0'
 ## File lists
 
 # Headers to be installed under ${prefix}/include/
-install_headers(files(
-        'include/taskolib/CommChannel.h',
-        'include/taskolib/console.h',
-        'include/taskolib/Context.h',
-        'include/taskolib/deserialize_sequence.h',
-        'include/taskolib/exceptions.h',
-        'include/taskolib/Executor.h',
-        'include/taskolib/format.h',
-        'include/taskolib/hash_string.h',
-        'include/taskolib/LockedQueue.h',
-        'include/taskolib/Message.h',
-        'include/taskolib/Sequence.h',
-        'include/taskolib/SequenceManager.h',
-        'include/taskolib/serialize_sequence.h',
-        'include/taskolib/Step.h',
-        'include/taskolib/StepIndex.h',
-        'include/taskolib/taskolib.h',
-        'include/taskolib/time_types.h',
-        'include/taskolib/VariableName.h',
-    ),
+public_headers = [
+   'include/taskolib/CommChannel.h',
+   'include/taskolib/console.h',
+   'include/taskolib/Context.h',
+   'include/taskolib/deserialize_sequence.h',
+   'include/taskolib/exceptions.h',
+   'include/taskolib/Executor.h',
+   'include/taskolib/format.h',
+   'include/taskolib/hash_string.h',
+   'include/taskolib/LockedQueue.h',
+   'include/taskolib/Message.h',
+   'include/taskolib/Sequence.h',
+   'include/taskolib/SequenceManager.h',
+   'include/taskolib/serialize_sequence.h',
+   'include/taskolib/Step.h',
+   'include/taskolib/StepIndex.h',
+   'include/taskolib/taskolib.h',
+   'include/taskolib/time_types.h',
+   'include/taskolib/VariableName.h',
+]
+install_headers(files(public_headers),
     subdir: 'taskolib',
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -50,6 +50,9 @@ foreach header_to_check : public_headers
     if header_to_check.startswith('include/') and header_to_check.endswith('.h')
         header_to_check = header_to_check.substring(8)
         header_name = header_to_check.split('.h')[0]
+        if not fmt_dep.found() and header_name.endswith('/format')
+            continue
+        endif
 
         header_conf = configuration_data()
         header_conf.set('HEADER_TO_INCLUDE', header_to_check)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,71 @@
+# Test sources
+test_src = files(
+    'test_CommChannel.cc',
+    'test_Context.cc',
+    'test_exceptions.cc',
+    'test_Executor.cc',
+    #'tests/test_format.cc' needs fmt{} library
+    'test_LockedQueue.cc',
+    'test_main.cc',
+    'test_Message.cc',
+    'test_Sequence.cc',
+    'test_SequenceManager.cc',
+    'test_serialize_sequence.cc',
+    'test_Step.cc',
+    'test_time_types.cc',
+    'test_VariableName.cc',
+)
+
+# The tests are executed in the build dir to avoid pollution of the git repository with
+# the test executable's output files
+test('all',
+    executable(meson.project_name() + '_test',
+        test_src,
+        dependencies : taskolib_dep,
+    ),
+    workdir : meson.current_build_dir(),
+    timeout : 10,
+)
+
+fmt_dep = dependency('fmt', required : false)
+if fmt_dep.found()
+    test('format',
+        executable(meson.project_name() + '_format_test',
+            [ 'test_format.cc', 'test_main.cc', ],
+            dependencies : [ taskolib_dep, dependency('fmt'), ],
+        ),
+        timeout : 10,
+    )
+endif
+
+######
+# Test if all headers are self-contained (Core Guidelines SF.11)
+# This is automated over all public_headers
+
+message('Generating self-containment tests')
+all_header_checks = [ ]
+loop_number = 0
+foreach header_to_check : public_headers
+    loop_number += 1
+    if header_to_check.startswith('include/') and header_to_check.endswith('.h')
+        header_to_check = header_to_check.substring(8)
+        header_name = header_to_check.split('.h')[0]
+
+        header_conf = configuration_data()
+        header_conf.set('HEADER_TO_INCLUDE', header_to_check)
+        header_conf.set('DUMMY_FUNCTION_NAME', 'a@0@'.format(loop_number))
+
+        header_check = configure_file(
+            input : 'test_self_containment.cc.in',
+            output : 'incl_' + header_name.split('/')[-1] + '.cc',
+            configuration : header_conf,
+        )
+        all_header_checks += [ header_check ]
+    endif
+endforeach
+
+static_library(
+    '_ignore_me', all_header_checks,
+    dependencies : taskolib_dep,
+    install : false,
+)

--- a/tests/test_self_containment.cc.in
+++ b/tests/test_self_containment.cc.in
@@ -1,0 +1,27 @@
+/**
+ * \file   test_self_containment.cc.in
+ * \author \ref contributors
+ * \date   Created on August 21, 2019
+ * \brief  Used to check if the individual headers are self-contained
+ *
+ * \copyright Copyright 2019 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "@HEADER_TO_INCLUDE@"
+
+void @DUMMY_FUNCTION_NAME@() {} // to prevent object files without any symbol
+
+// vi:ts=4:sw=4:sts=4:et


### PR DESCRIPTION
Do a header self-containment test.
And find headers that have bugs, but that we do not include in the normal build/test processes.

See https://github.com/taskolib/taskolib/pull/27#discussion_r1010232305