### PR TITLE
Step: Add bool and nil context variable types

### DIFF
--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -42,9 +42,14 @@ namespace task {
 /**
  * A VariableValue is a variant over several data types (long long, double, std::string).
  *
+ * The char pointer will be converted to a std::string when the variable is imported
+ * into a Step by copying the contents. That can be a long time after assignment.
+ * Be careful with the lifetime of the pointed to string; it must outlife the Context.
+ * Normally you should prefer to hand over std::string.
+ *
  * Names are associated with these values via a map in the Context type.
  */
-using VariableValue = std::variant<long long, double, std::string, bool>;
+using VariableValue = std::variant<long long, double, std::string, char const*, bool>;
 
 /**
  * Associative table that holds Lua variable names and their value.

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -44,7 +44,7 @@ namespace task {
  *
  * Names are associated with these values via a map in the Context type.
  */
-using VariableValue = std::variant<long long, double, std::string>;
+using VariableValue = std::variant<long long, double, std::string, bool>;
 
 /**
  * Associative table that holds Lua variable names and their value.

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -42,14 +42,9 @@ namespace task {
 /**
  * A VariableValue is a variant over several data types (long long, double, std::string).
  *
- * The char pointer will be converted to a std::string when the variable is imported
- * into a Step by copying the contents. That can be a long time after assignment.
- * Be careful with the lifetime of the pointed to string; it must outlife the Context.
- * Normally you should prefer to hand over std::string.
- *
  * Names are associated with these values via a map in the Context type.
  */
-using VariableValue = std::variant<long long, double, std::string, char const*, bool>;
+using VariableValue = std::variant<long long, double, std::string, bool>;
 
 /**
  * Associative table that holds Lua variable names and their value.

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -40,9 +40,13 @@
 namespace task {
 
 /**
- * A VariableValue is a variant over several data types (long long, double, std::string).
+ * A VariableValue is a variant over several data types Lua can understand (long long, double, std::string, bool).
  *
- * Names are associated with these values via a map in the Context type.
+ * Variable names are associated with these values via a map in the Context class.
+ *
+ * Be careful when assigning a string to a VariableValue:
+ * Do not use a char* to pass the string, it might be converted to bool instead
+ * of the expected std::string. The conversion depends on the used compiler (version).
  */
 using VariableValue = std::variant<long long, double, std::string, bool>;
 
@@ -71,7 +75,7 @@ using OutputCallback =
  */
 struct Context
 {
-    /// A list of variables that can be im-/exported into steps.
+    /// A map of variables (names and values) that can be im-/exported into steps.
     VariableTable variables;
 
     /// An initialization function that is called on a LUA state before a step is executed.

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -62,9 +62,12 @@ void Step::copy_used_variables_from_context_to_lua(const Context& context, sol::
                 using T = std::decay_t<decltype(value)>;
 
                 if constexpr (std::is_same_v<T, double> or std::is_same_v<T, long long> or
-                              std::is_same_v<T, std::string>)
+                              std::is_same_v<T, std::string> or std::is_same_v<T, bool>)
                 {
                     lua[varname_str] = value;
+                }
+                else if constexpr (std::is_same_v<T, sol::lua_nil_t>) {
+                    lua[varname_str] = sol::lua_nil_t{ };
                 }
                 else
                 {
@@ -93,6 +96,12 @@ void Step::copy_used_variables_from_lua_to_context(const sol::state& lua, Contex
                 break;
             case sol::type::string:
                 context.variables[varname] = VariableValue{ var.as<std::string>() };
+                break;
+            case sol::type::boolean:
+                context.variables[varname] = VariableValue{ var.as<bool>() };
+                break;
+            case sol::type::lua_nil:
+                context.variables.erase(varname);
                 break;
             default:
                 break;

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -66,12 +66,7 @@ void Step::copy_used_variables_from_context_to_lua(const Context& context, sol::
                 {
                     lua[varname_str] = value;
                 }
-                else if constexpr (std::is_same_v<T, char const*>)
-                {
-                    lua[varname_str] = std::string{ value };
-                }
-                else if constexpr (std::is_same_v<T, sol::lua_nil_t>)
-                {
+                else if constexpr (std::is_same_v<T, sol::lua_nil_t>) {
                     lua[varname_str] = sol::lua_nil_t{ };
                 }
                 else

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -66,7 +66,12 @@ void Step::copy_used_variables_from_context_to_lua(const Context& context, sol::
                 {
                     lua[varname_str] = value;
                 }
-                else if constexpr (std::is_same_v<T, sol::lua_nil_t>) {
+                else if constexpr (std::is_same_v<T, char const*>)
+                {
+                    lua[varname_str] = std::string{ value };
+                }
+                else if constexpr (std::is_same_v<T, sol::lua_nil_t>)
+                {
                     lua[varname_str] = sol::lua_nil_t{ };
                 }
                 else

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -78,6 +78,9 @@ TEST_CASE("Context: Move assignment", "[Context]")
 TEST_CASE("Check context variable assignment", "[Context]")
 {
     Context c;
+    // Never assign a char* like this: c.variables["b"] = "BooleanTest";
+    // Some compilers fill this into the bool alternative!
+    // See PR #33 for details.
     c.variables["b"] = "BooleanTest"s; // assigns std::string
     REQUIRE(std::holds_alternative<bool>(c.variables["b"]) == false);
     REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == true);

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -78,8 +78,8 @@ TEST_CASE("Context: Move assignment", "[Context]")
 TEST_CASE("Check context variable assignment", "[Context]")
 {
     Context c;
-    c.variables["b"] = "BooleanTest";
+    c.variables["b"] = "BooleanTest"s; // assigns std::string
     REQUIRE(std::holds_alternative<bool>(c.variables["b"]) == false);
-    REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == false);
-    REQUIRE(std::get<char const*>(c.variables["b"]) == "BooleanTest"s);
+    REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == true);
+    REQUIRE(std::get<std::string>(c.variables["b"]) == "BooleanTest");
 }

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -80,6 +80,6 @@ TEST_CASE("Check context variable assignment", "[Context]")
     Context c;
     c.variables["b"] = "BooleanTest";
     REQUIRE(std::holds_alternative<bool>(c.variables["b"]) == false);
-    REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == true);
-    REQUIRE(std::get<std::string>(c.variables["b"]) == "BooleanTest");
+    REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == false);
+    REQUIRE(std::get<char const*>(c.variables["b"]) == "BooleanTest"s);
 }

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -74,3 +74,12 @@ TEST_CASE("Context: Move assignment", "[Context]")
 
     c2 = std::move(c);
 }
+
+TEST_CASE("Check context variable assignment", "[Context]")
+{
+    Context c;
+    c.variables["b"] = "BooleanTest";
+    REQUIRE(std::holds_alternative<bool>(c.variables["b"]) == false);
+    REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == true);
+    REQUIRE(std::get<std::string>(c.variables["b"]) == "BooleanTest");
+}

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -1208,6 +1208,67 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.execute(ctx, nullptr);
         REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
     }
+    SECTION("Hand bool variable over context without initial value") {
+        Step s1;
+        s1.set_script("a = 2; b = true"); // semicolon for the C people, Lua ignores it
+        s1.set_used_context_variable_names(VariableNames{"a", "b"});
+        Step s2;
+        s2.set_script("if b then a = a + 2 end");
+        s2.set_used_context_variable_names(VariableNames{"a", "b"});
+
+        seq.push_back(s1);
+        seq.push_back(s2);
+        seq.execute(ctx, nullptr);
+        CAPTURE(std::get<long long>(ctx.variables["a"]));
+        REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
+    }
+    SECTION("Hand nil variable over context without initial value") {
+        Step s1;
+        s1.set_script("a = 2; b = true"); // semicolon for the C people, Lua ignores it
+        s1.set_used_context_variable_names(VariableNames{"a", "b"});
+        Step s2;
+        s2.set_script("if b then a = a + 2 end; b = nil");
+        s2.set_used_context_variable_names(VariableNames{"a", "b"});
+        Step s3;
+        s3.set_script("if b then a = a + 2 end");
+        s3.set_used_context_variable_names(VariableNames{"a", "b"});
+
+        seq.push_back(s1);
+        seq.push_back(s2);
+        seq.push_back(s3);
+        seq.execute(ctx, nullptr);
+        CAPTURE(std::get<long long>(ctx.variables["a"]));
+        REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
+        REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
+    }
+    SECTION("Check nil is really non-existing") {
+        Step s1;
+        s1.set_script("b = 0"); // create variable b
+        s1.set_used_context_variable_names(VariableNames{"a", "b"});
+        Step s2;
+        // In Lua _G is the global table, that contains all 'root' variables
+        // (and functions, as all functions are just variables with closures).
+        // The following explicitly checks if variable `b` is really present/absent
+        // in/of the global table.
+        // This check is of course superstitious, Lua should handle it that way anyhow.
+        // It shows nicely the analogy of our ctx.variables table and Lua's _G table.
+        s2.set_script("for k, _ in pairs(_G) do if k == 'b' then a = a + 1 end end");
+        s2.set_used_context_variable_names(VariableNames{"a", "b"});
+        Step s3;
+        s3.set_script("b = nil"); // remove variable b
+        s3.set_used_context_variable_names(VariableNames{"a", "b"});
+        Step s4;
+        s4.set_script("for k, _ in pairs(_G) do if k == 'b' then a = a + 1 end end");
+        s4.set_used_context_variable_names(VariableNames{"a", "b"});
+        seq.push_back(s1);
+        seq.push_back(s2);
+        seq.push_back(s3);
+        seq.push_back(s4);
+        seq.execute(ctx, nullptr);
+        CAPTURE(std::get<long long>(ctx.variables["a"]));
+        REQUIRE(ctx.variables["a"] == VariableValue{ 1LL } );
+        REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
+    }
 }
 
 TEST_CASE("execute(): complex sequence with prohibited LUA function", "[Sequence]")

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -631,10 +631,13 @@ TEST_CASE("execute(): Exporting variables into a context", "[Step]")
 
     SECTION("No exported variables")
     {
+        // Variable 'b' is not touched (imported into any Step), so if it holds
+        // a char const* it will not be converted to std::string.
         context.variables["b"] = "Test";
         step.execute(context);
         REQUIRE(context.variables.size() == 1);
-        REQUIRE(std::get<std::string>(context.variables["b"]) == "Test");
+        // REQUIRE(std::get<std::string>(context.variables["b"]) == "Test"s);
+        REQUIRE(std::get<char const*>(context.variables["b"]) == "Test"s);
     }
 
     SECTION("Exporting an integer")

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -631,13 +631,10 @@ TEST_CASE("execute(): Exporting variables into a context", "[Step]")
 
     SECTION("No exported variables")
     {
-        // Variable 'b' is not touched (imported into any Step), so if it holds
-        // a char const* it will not be converted to std::string.
-        context.variables["b"] = "Test";
+        context.variables["b"] = "Test"s;
         step.execute(context);
         REQUIRE(context.variables.size() == 1);
-        // REQUIRE(std::get<std::string>(context.variables["b"]) == "Test"s);
-        REQUIRE(std::get<char const*>(context.variables["b"]) == "Test"s);
+        REQUIRE(std::get<std::string>(context.variables["b"]) == "Test");
     }
 
     SECTION("Exporting an integer")
@@ -723,7 +720,7 @@ TEST_CASE("execute(): Running a step with multiple import and exports", "[Step]"
 
     SECTION("num_repetitions < 0 returns false")
     {
-        context.variables["str"] = "Test";
+        context.variables["str"] = "Test"s;
         context.variables["num_repetitions"] = -1LL;
         REQUIRE(step.execute(context) == false);
         REQUIRE(context.variables.size() == 2);
@@ -733,7 +730,7 @@ TEST_CASE("execute(): Running a step with multiple import and exports", "[Step]"
 
     SECTION("num_repetitions == 0 returns empty string")
     {
-        context.variables["str"] = "Test";
+        context.variables["str"] = "Test"s;
         context.variables["num_repetitions"] = 0LL;
         REQUIRE(step.execute(context) == true);
         REQUIRE(context.variables.size() == 3);
@@ -744,9 +741,9 @@ TEST_CASE("execute(): Running a step with multiple import and exports", "[Step]"
 
     SECTION("num_repetitions == 2 with separator")
     {
-        context.variables["str"] = "Test";
+        context.variables["str"] = "Test"s;
         context.variables["num_repetitions"] = 2LL;
-        context.variables["separator"] = "|";
+        context.variables["separator"] = "|"s;
         REQUIRE(step.execute(context) == true);
         REQUIRE(context.variables.size() == 4);
         REQUIRE(std::get<std::string>(context.variables["str"]) == "Test");


### PR DESCRIPTION
**[why]**
These two basic Lua types can not be forwarded from one step to the next.
    
**[how]**
Add the `bool` type just like the others.

`nil` in Lua means 'does not exist', so `x = nil` means that the variable
`x` becomes non-existing afterwards. That means that we need to remove the
variable also from the context in that case. We do not need a 'nil
type'; `nil` is just the absence of anything there.
    
The Lua types `userdata`, `function`, and `table` can still not be
forwarded from one Step to the next.
    
Fixes: #32