### PR TITLE
Refactor abort handling and suppress abort markers in Step error messages

### DIFF
--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -315,31 +315,31 @@ void Sequence::execute(Context& context, CommChannel* comm)
 
     if (exception_thrown)
     {
-        const auto cause = remove_abort_markers_from_error_message(exception_message);
+        auto [msg, cause] = remove_abort_markers(exception_message);
 
         switch (cause)
         {
         case ErrorCause::terminated_by_script:
-            send_message(comm, Message::Type::sequence_stopped, exception_message,
-                         Clock::now(), maybe_exception_index);
+            send_message(comm, Message::Type::sequence_stopped, msg, Clock::now(),
+                         maybe_exception_index);
             return; // silently return to the caller
         case ErrorCause::aborted:
-            exception_message = "Sequence aborted: " + exception_message;
+            msg = "Sequence aborted: " + msg;
             break;
         case ErrorCause::uncaught_error:
-            exception_message = "Sequence stopped with error: " + exception_message;
+            msg = "Sequence stopped with error: " + msg;
             break;
         }
 
-        send_message(comm, Message::Type::sequence_stopped_with_error, exception_message,
-                     Clock::now(), maybe_exception_index);
-        set_error_message(exception_message);
+        send_message(comm, Message::Type::sequence_stopped_with_error, msg, Clock::now(),
+                     maybe_exception_index);
+        set_error_message(msg);
 
-        throw Error(exception_message);
+        throw Error(msg);
     }
 
-    send_message(comm, Message::Type::sequence_stopped, "Sequence finished",
-                 Clock::now(), gul14::nullopt);
+    send_message(comm, Message::Type::sequence_stopped, "Sequence finished", Clock::now(),
+                 gul14::nullopt);
 }
 
 Sequence::Iterator

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -155,12 +155,11 @@ bool Step::execute(Context& context, CommChannel* comm, StepIndex index)
 
     if (std::holds_alternative<std::string>(result_or_error))
     {
-        const std::string& raw_msg = std::get<std::string>(result_or_error);
-        std::string laundered_msg = raw_msg;
-        remove_abort_markers_from_error_message(laundered_msg);
+        const auto& raw_msg = std::get<std::string>(result_or_error);
+        auto [msg, _] = remove_abort_markers(raw_msg);
 
-        send_message(comm, Message::Type::step_stopped_with_error, laundered_msg,
-                     Clock::now(), index);
+        send_message(comm, Message::Type::step_stopped_with_error, msg, Clock::now(),
+                     index);
         throw ErrorAtIndex(raw_msg, index);
     }
 

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -26,6 +26,7 @@
 #include <gul14/finalizer.h>
 #include <gul14/trim.h>
 
+#include "internals.h"
 #include "lua_details.h"
 #include "sol/sol.hpp"
 #include "taskolib/exceptions.h"
@@ -154,10 +155,13 @@ bool Step::execute(Context& context, CommChannel* comm, StepIndex index)
 
     if (std::holds_alternative<std::string>(result_or_error))
     {
-        const auto& msg = std::get<std::string>(result_or_error);
-        send_message(comm, Message::Type::step_stopped_with_error, msg, Clock::now(),
-                     index);
-        throw ErrorAtIndex(msg, index);
+        const std::string& raw_msg = std::get<std::string>(result_or_error);
+        std::string laundered_msg = raw_msg;
+        remove_abort_markers_from_error_message(laundered_msg);
+
+        send_message(comm, Message::Type::step_stopped_with_error, laundered_msg,
+                     Clock::now(), index);
+        throw ErrorAtIndex(raw_msg, index);
     }
 
     send_message(comm, Message::Type::step_stopped,

--- a/src/internals.cc
+++ b/src/internals.cc
@@ -2,7 +2,7 @@
  * \file   internals.cc
  * \author Lars Froehlich, Marcus Walla
  * \date   Created on August 30, 2022
- * \brief  Definition of internal constants.
+ * \brief  Definition of internal constants and functions.
  *
  * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -22,10 +22,37 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <gul14/join_split.h>
+#include <gul14/SmallVector.h>
+
 #include "internals.h"
 
 namespace task {
 
 const gul14::string_view abort_marker{ u8"\U0001F6D1ABORT\U0001F6D1" };
+
+ErrorCause remove_abort_markers_from_error_message(std::string& msg)
+{
+    const auto tokens = gul14::split<gul14::SmallVector<gul14::string_view, 3>>(
+        msg, abort_marker);
+
+    if (tokens.size() >= 3) // The real error message is between the first 2 abort markers
+        msg.assign(tokens[1].begin(), tokens[1].end());
+    else
+        msg = gul14::join(tokens, "");
+
+    if (tokens.size() > 1) // There was at least one abort marker
+    {
+        if (msg.empty())
+        {
+            msg = "Script called terminate_sequence()";
+            return ErrorCause::terminated_by_script;
+        }
+
+        return ErrorCause::aborted;
+    }
+
+    return ErrorCause::uncaught_error;
+}
 
 } // namespace task

--- a/src/internals.h
+++ b/src/internals.h
@@ -2,7 +2,7 @@
  * \file   internals.h
  * \author Lars Froehlich, Marcus Walla
  * \date   Created on August 30, 2022
- * \brief  Declaration of internal constants.
+ * \brief  Declaration of internal constants and functions.
  *
  * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -25,6 +25,7 @@
 #ifndef TASKOLIB_INTERNALS_H_
 #define TASKOLIB_INTERNALS_H_
 
+#include <string>
 #include <gul14/string_view.h>
 
 namespace task {
@@ -34,6 +35,26 @@ namespace task {
  * anywhere in an error message signals that the execution of a script should be stopped.
  */
 extern const gul14::string_view abort_marker;
+
+enum class ErrorCause { terminated_by_script, aborted, uncaught_error };
+
+/**
+ * Remove abort markers from the given error message and determine the cause of the error.
+ *
+ * All abort markers are removed from the given error message. If no marker was present,
+ * the message describes a "normal" error and ErrorCause::uncaught_error is returned.
+ *
+ * If the message contains at least two abort markers and there is no message enclosed
+ * between the first two of them, this is considered an explicit termination request by
+ * the running script. The error message is set to a corresponding explanation ("Script
+ * called terminate_sequence()") and ErrorCause::terminated_by_script is returned.
+ *
+ * If the error message contains at least one abort marker and an error message, it is
+ * considered an abort request (either by the user or by timeouts) and ErrorCause::aborted
+ * is returned. If there are at least two abort markers, the error message is set to the
+ * text enclosed by the first two of them.
+ */
+ErrorCause remove_abort_markers_from_error_message(std::string& msg);
 
 } // namespace task
 

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -199,13 +199,8 @@ void install_custom_commands(sol::state& lua, const Context& context)
     auto globals = lua.globals();
     globals["print"] = make_print_fct(context.print_function);
     globals["sleep"] = sleep_fct;
-
-    // throw exception with special message 'TERMINATE_SEQUENCE' to exit the sequence
-    globals["terminate_sequence"] = [&lua]
-    {
-        // TODO Possible set here a predefined error string, for example "user abort"
-        abort_script_with_error(lua.lua_state(), "");
-    };
+    globals["terminate_sequence"] =
+        [](sol::this_state lua){ abort_script_with_error(lua, ""); };
 }
 
 void install_timeout_and_termination_request_hook(sol::state& lua, TimePoint now,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,7 @@ test_src = files(
     'test_exceptions.cc',
     'test_Executor.cc',
     #'tests/test_format.cc' needs fmt{} library
+    'test_internals.cc',
     'test_LockedQueue.cc',
     'test_main.cc',
     'test_Message.cc',

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -3440,7 +3440,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
     REQUIRE(queue.size() == 26);
     auto msg = queue.back();
     REQUIRE(msg.get_type() == Message::Type::sequence_stopped);
-    REQUIRE(msg.get_text() == "Sequence explicitly terminated");
+    REQUIRE(msg.get_text() == "Script called terminate_sequence()");
     REQUIRE(msg.get_index().has_value());
     REQUIRE(*(msg.get_index()) == 2);
 }

--- a/tests/test_internals.cc
+++ b/tests/test_internals.cc
@@ -1,0 +1,92 @@
+/**
+ * \file   test_internals.cc
+ * \author Lars Froehlich
+ * \date   Created on November 4, 2022
+ * \brief  Test suite for internal functions.
+ *
+ * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gul14/cat.h>
+#include <gul14/catch.h>
+
+#include "../src/internals.h"
+
+using gul14::cat;
+using namespace task;
+using namespace Catch::Matchers;
+
+TEST_CASE("remove_abort_markers_from_error_message()", "[internals]")
+{
+    std::string msg;
+
+    SECTION("Empty message")
+    {
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::uncaught_error);
+        REQUIRE(msg.empty());
+    }
+
+    SECTION("Normal error message")
+    {
+        msg = "This is an error message";
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::uncaught_error);
+        REQUIRE(msg == "This is an error message");
+    }
+
+    SECTION("Script termination (abort marker(s) without message)")
+    {
+        msg = std::string(abort_marker);
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::terminated_by_script);
+        REQUIRE(msg == "Script called terminate_sequence()");
+
+        msg = gul14::cat(abort_marker, abort_marker);
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::terminated_by_script);
+        REQUIRE(msg == "Script called terminate_sequence()");
+
+        msg = gul14::cat("lorem ipsum", abort_marker, abort_marker, "dolor sit");
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::terminated_by_script);
+        REQUIRE(msg == "Script called terminate_sequence()");
+
+        msg = gul14::cat("lorem ipsum", abort_marker, abort_marker, "dolor sit", abort_marker, "amet");
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::terminated_by_script);
+        REQUIRE(msg == "Script called terminate_sequence()");
+    }
+
+    SECTION("Abort with error message")
+    {
+        msg = cat(abort_marker, "hydrogen", abort_marker);
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::aborted);
+        REQUIRE(msg == "hydrogen");
+
+        msg = cat(abort_marker, "helium");
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::aborted);
+        REQUIRE(msg == "helium");
+
+        msg = cat("lithium", abort_marker);
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::aborted);
+        REQUIRE(msg == "lithium");
+
+        msg = cat("beryll", abort_marker, "ium");
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::aborted);
+        REQUIRE(msg == "beryllium");
+
+        msg = cat("waste of ", abort_marker, "boron", abort_marker, " sucks");
+        REQUIRE(remove_abort_markers_from_error_message(msg) == ErrorCause::aborted);
+        REQUIRE(msg == "boron");
+    }
+}


### PR DESCRIPTION
By default, `Step` errors are reported via the *error* channel and probably displayed to the user (the DOOCS Taskomat does that by default). As such error messages should never contain our internal abort marker, this PR goes to some length to filter them out.

We implement a new function `remove_abort_markers_from_error_message()` and add unit tests for it. This function is used both in `Sequence::execute()` and in `Step::execute()` to find and remove abort markers. It also interprets the meaning of the abort markers and returns one of the enum class values `uncaught_error`, `terminated_by_script`, or `aborted`.
