### PR TITLE
Sol: Fix clang compiler warning

### DIFF
--- a/include/taskolib/sol/sol/sol.hpp
+++ b/include/taskolib/sol/sol/sol.hpp
@@ -14538,7 +14538,10 @@ namespace sol { namespace stack {
 
 #if SOL_IS_ON(SOL_COMPILER_GCC)
 #pragma GCC diagnostic push
+// TASKOLIB modification:
+#if !SOL_IS_ON(SOL_COMPILER_CLANG)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 	namespace stack_detail {
@@ -17291,7 +17294,10 @@ namespace sol {
 
 #if SOL_IS_ON(SOL_COMPILER_GCC)
 #pragma GCC diagnostic push
+// TASKOLIB modification:
+#if !SOL_IS_ON(SOL_COMPILER_CLANG)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 		template <typename T>

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -37,7 +37,7 @@ using gul14::cat;
 namespace {
 
 template <typename>
-inline constexpr bool always_false_v = false;
+[[maybe_unused]] inline constexpr bool always_false_v = false;
 
 } // anonymous namespace
 


### PR DESCRIPTION
**[why]**
Compiling with clang issues this warning (clang 10.0 and 15.0 tested):

```
../include/taskolib/sol/sol/sol.hpp:14541:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
                               ^
../include/taskolib/sol/sol/sol.hpp:17294:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
```

**[how]**
Check if the compiler does know the warning, before trying to turn the warning off.

**[note]**
Also remove warning:

    ../src/Step.cc:40:23: warning: unused variable 'always_false_v' [-Wunused-const-variable]
    inline constexpr bool always_false_v = false;
                          ^

(The function is only used when we want to throw an assertion.)


See also https://github.com/ThePhD/sol2/pull/1418