### PR TITLE
Bugfix: Do not overwrite executor context

### DIFF
--- a/include/taskolib/Executor.h
+++ b/include/taskolib/Executor.h
@@ -179,9 +179,11 @@ private:
     std::shared_ptr<CommChannel> comm_channel_;
 
     /**
-     * A future holding the results of the execution thread.
+     * A future for the result of the execution thread.
+     * Once the thread has joined, it contains the context variables from the executed
+     * sequence.
      */
-    std::future<Context> future_;
+    std::future<VariableTable> future_;
 
     /**
      * A local copy of the context that was used to start the last sequence.
@@ -194,8 +196,8 @@ private:
      * This is the function running in the execution thread: It calls Sequence::execute()
      * and silently swallows all exceptions.
      */
-    static Context execute_sequence(Sequence sequence, Context context,
-                                 std::shared_ptr<CommChannel> comm_channel) noexcept;
+    static VariableTable execute_sequence(Sequence sequence, Context context,
+        std::shared_ptr<CommChannel> comm_channel) noexcept;
 };
 
 } // namespace task

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -72,12 +72,12 @@ void Executor::cancel()
         return;
 
     comm_channel_->immediate_termination_requested_ = true;
-    context_ = future_.get(); // Wait for thread to join
+    context_.variables = future_.get(); // Wait for thread to join
     comm_channel_->immediate_termination_requested_ = false;
 }
 
-Context Executor::execute_sequence(Sequence sequence, Context context,
-                                std::shared_ptr<CommChannel> comm) noexcept
+VariableTable Executor::execute_sequence(Sequence sequence, Context context,
+                                         std::shared_ptr<CommChannel> comm) noexcept
 {
     try
     {
@@ -88,7 +88,7 @@ Context Executor::execute_sequence(Sequence sequence, Context context,
         // Silently ignore any thrown exception - the sequence already takes care of
         // sending the appropriate messages.
     }
-    return context;
+    return context.variables;
 }
 
 bool Executor::is_busy()
@@ -101,7 +101,7 @@ bool Executor::is_busy()
     if (status == std::future_status::timeout)
         return true;
 
-    context_ = future_.get();
+    context_.variables = future_.get();
     return false;
 }
 

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -271,10 +271,23 @@ TEST_CASE("Executor: Redirection of print() output", "[Executor]")
 
     executor.run_asynchronously(sequence, context);
 
-    while (executor.update(sequence))
-        gul14::sleep(5ms);
+    SECTION("Regularly calling update()")
+    {
+        while (executor.update(sequence))
+            gul14::sleep(5ms);
 
-    REQUIRE(output == "Mary had\t3\tlittle lambs.\n");
+        REQUIRE(output == "Mary had\t3\tlittle lambs.\n");
+    }
+
+    SECTION("Regularly calling busy() and update() only at the end")
+    {
+        while (executor.is_busy())
+            gul14::sleep(5ms);
+        executor.update(sequence);
+
+        // Causes a test failure with a buggy implementation of is_busy()
+        REQUIRE(output == "Mary had\t3\tlittle lambs.\n");
+    }
 }
 
 TEST_CASE("Executor: Access context after run", "[Executor]")


### PR DESCRIPTION
This PR adds a test that demonstrates issue #40 (`Executor` context being overwritten indiscriminately when running a parallel sequence) and implements a fix.
    
**[why]**
A sequence executed in parallel by an `Executor` should sync back its context variables to the calling thread, but it accidentally synced back the entire context. This effectively overwrote other fields, most notably the output functions.
    
**[how]**
Return only the variables in `Executor`'s future, not the entire `Context` object.

Fixes #40.
    