### PR TITLE
Process error messages in execute_lua_script_safely()

### DIFF
--- a/include/taskolib/sol/sol/config.hpp
+++ b/include/taskolib/sol/sol/config.hpp
@@ -44,8 +44,10 @@ the build system, or the command line options of your compiler.
 // Do not produce console output on certain errors
 #define SOL_PRINT_ERRORS 0
 
-// Enable maximum amount of safety checks
-// #define SOL_ALL_SAFETIES_ON 1
+// Enable maximum amount of safety checks (for instance, this enables somewhat meaningful
+// error messages if strange C++ exceptions that are not derived from std::exception are
+// thrown during Lua script execution)
+#define SOL_ALL_SAFETIES_ON 1
 
 // end of sol/config.hpp
 

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -130,7 +130,7 @@ execute_lua_script_safely(sol::state& lua, sol::string_view script)
             if (msg.empty() ||
                 msg == "lua: error: stack index 1, expected string, received function")
             {
-                return "Unknown C++ exception";
+                return "Unknown exception";
             }
 
             return gul14::replace(msg, chunk_prefix, "");

--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -56,7 +56,10 @@ void check_script_timeout(lua_State* lua_state);
  *
  * This function returns a variant: If the Lua script finishes without error, it contains
  * a sol::object representing the return value of the script. If a Lua error or C++
- * exception occurs, the variant contains a string with an error message.
+ * exception occurs, the variant contains a string with an error message. The error
+ * message is pre-processed to a certain degree: Unhelpful parts like the chunk name of
+ * the script (`[string "..."]:`) are removed, and a few known special messages are
+ * replaced by more readable explanations.
  */
 std::variant<sol::object, std::string>
 execute_lua_script_safely(sol::state& lua, sol::string_view script);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ test_src = files(
     #'tests/test_format.cc' needs fmt{} library
     'test_internals.cc',
     'test_LockedQueue.cc',
+    'test_lua_details.cc',
     'test_main.cc',
     'test_Message.cc',
     'test_Sequence.cc',

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -394,8 +394,7 @@ TEST_CASE("execute(): Lua exceptions", "[Step]")
         }
         catch(const Error& e)
         {
-            REQUIRE_THAT(e.what(), Contains("Script execution error"));
-            REQUIRE_THAT(e.what(), Contains("pippo"));
+            REQUIRE_THAT(e.what(), StartsWith("pippo"));
             // Lua adds a stack trace after this output. This is a somewhat brittle test,
             // but since we have control over our Lua version, we are sure to spot it if
             // the output format changes.

--- a/tests/test_lua_details.cc
+++ b/tests/test_lua_details.cc
@@ -127,7 +127,8 @@ TEST_CASE("execute_lua_script_safely(): Lua exceptions", "[lua_details]")
             lua, "function boom(); error('', 0); end; boom()");
         auto* msg = std::get_if<std::string>(&result_or_error);
         REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, not Contains("Unknown C++ exception"));
+        REQUIRE_THAT(*msg, not Contains("Unknown"));
+        REQUIRE_THAT(*msg, not Contains("exception"));
     }
 
     SECTION("Runtime error, caught by pcall()")
@@ -164,7 +165,8 @@ TEST_CASE("execute_lua_script_safely(): C++ exceptions", "[Step]")
             lua, "throw_logic_error_without_msg()");
         auto* msg = std::get_if<std::string>(&result_or_error);
         REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, not Contains("Unknown C++ exception"));
+        REQUIRE_THAT(*msg, not Contains("Unknown"));
+        REQUIRE_THAT(*msg, not Contains("exception"));
     }
 
     SECTION("Nonstandard C++ exceptions are reported as errors")
@@ -173,7 +175,7 @@ TEST_CASE("execute_lua_script_safely(): C++ exceptions", "[Step]")
             lua, "throw_weird_exception()");
         auto* msg = std::get_if<std::string>(&result_or_error);
         REQUIRE(msg != nullptr);
-        REQUIRE(*msg == "Unknown C++ exception");
+        REQUIRE(*msg == "Unknown exception");
     }
 
     SECTION("Standard C++ exceptions are converted to Lua errors and caught by pcall()")


### PR DESCRIPTION
**[why]**
Error messages from Sol2 are usually littered with unhelpful references to the chunk name (`[string "..."]:`) both at the beginning of the message and within the stack trace. This chunk name is useful for normal file-based Lua execution, but not in our case where only one string is executed.
Also, throwing a C++ exception not derived from `std::exception` from within Lua causes the confusing error message:
```
lua: error: stack index 1, expected string, received function
``` 
See the comment in the code for an explanation.
    
**[how]**
Set the chunk name to an unlikely Unicode character (an anchor symbol) and remove the chunk name references via `replace()`. Also, if the error message is the one above, return "Unknown C++ exception" instead.