### PR TITLE
CI: Make error logs availabe if CI fails

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -59,7 +59,23 @@ jobs:
         ./meson.py --buildtype=release build.release
         ./meson.py --buildtype=debug build.asan -Db_sanitize=address
     - name: Build and run release tests
+      id: buildnormal
       run: ./meson.py test -C build.release
 
+    - name: Save error logs
+      uses: actions/upload-artifact@v3
+      if: ${{ always() && steps.buildnormal.outcome == 'failure' }}
+      with:
+        name: Meson-logs-${{ matrix.os }}
+        path: build.release/meson-logs/
+
     - name: Build and run ASAN tests
+      id: buildasan
       run: ./meson.py test -C build.asan
+
+    - name: Save error logs
+      uses: actions/upload-artifact@v3
+      if: ${{ always() && steps.buildasan.outcome == 'failure' }}
+      with:
+        name: Meson-logs-${{ matrix.os }}
+        path: build.asan/meson-logs/


### PR DESCRIPTION
**[why]**
We recently had a PR that had failing tests in the CI, but you can not look into the details.

**[how]**
Add a build artifact with the Meson logs if the build fails.