### PR TITLE
Test only strictly guaranteed conditions

### DIFF
--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -422,8 +422,6 @@ TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
     Executor executor{ };
     executor.run_asynchronously(seq, ctx);
 
-    REQUIRE(executor.is_busy() == true);
-    REQUIRE(executor.update(seq) == true);
     REQUIRE(seq.is_running() == true);
 
     while (executor.update(seq))


### PR DESCRIPTION
**[why]**
The "run sequence asynchronously with throw" test for the Executor class tested for `Executor::is_busy()` directly after an `Executor::run_asynchronously()` call. While this is very likely to return true, it is not guaranteed and actually fails on some Github test systems.

**[how]**
Test only for conditions that are independent of timing.