### PR TITLE
Introduce aliases for Lua types

### DIFF
--- a/examples/execute_step.cc
+++ b/examples/execute_step.cc
@@ -12,17 +12,17 @@ int main()
 
     // Create a context and store values for "a" and "b" in it
     Context context;
-    context.variables["a"] = StepVariable::Integer{ 42 };
-    context.variables["b"] = StepVariable::Float{ -41.5 };
+    context.variables["a"] = VarInteger{ 42 };
+    context.variables["b"] = VarFloat{ -41.5 };
 
     // Execute the step with the context
     step.execute(context);
 
     // Retrieve variables from the context with std::get()
     std::cout << "According to LUA, the sum of "
-              << std::get<StepVariable::Integer>(context.variables["a"])
-              << " and " << std::get<StepVariable::Float>(context.variables["b"]) << " is "
-              << std::get<StepVariable::Float>(context.variables["sum"]) << ".\n";
+              << std::get<VarInteger>(context.variables["a"])
+              << " and " << std::get<VarFloat>(context.variables["b"]) << " is "
+              << std::get<VarFloat>(context.variables["sum"]) << ".\n";
 
     return 0;
 }

--- a/examples/execute_step.cc
+++ b/examples/execute_step.cc
@@ -12,17 +12,17 @@ int main()
 
     // Create a context and store values for "a" and "b" in it
     Context context;
-    context.variables["a"] = LuaInteger{ 42 };
-    context.variables["b"] = LuaFloat{ -41.5 };
+    context.variables["a"] = StepVariable::Integer{ 42 };
+    context.variables["b"] = StepVariable::Float{ -41.5 };
 
     // Execute the step with the context
     step.execute(context);
 
     // Retrieve variables from the context with std::get()
     std::cout << "According to LUA, the sum of "
-              << std::get<LuaInteger>(context.variables["a"])
-              << " and " << std::get<LuaFloat>(context.variables["b"]) << " is "
-              << std::get<LuaFloat>(context.variables["sum"]) << ".\n";
+              << std::get<StepVariable::Integer>(context.variables["a"])
+              << " and " << std::get<StepVariable::Float>(context.variables["b"]) << " is "
+              << std::get<StepVariable::Float>(context.variables["sum"]) << ".\n";
 
     return 0;
 }

--- a/examples/execute_step.cc
+++ b/examples/execute_step.cc
@@ -12,17 +12,17 @@ int main()
 
     // Create a context and store values for "a" and "b" in it
     Context context;
-    context.variables["a"] = 42LL;
-    context.variables["b"] = -41.5;
+    context.variables["a"] = LuaInteger{ 42 };
+    context.variables["b"] = LuaFloat{ -41.5 };
 
     // Execute the step with the context
     step.execute(context);
 
     // Retrieve variables from the context with std::get()
     std::cout << "According to LUA, the sum of "
-              << std::get<long long>(context.variables["a"])
-              << " and " << std::get<double>(context.variables["b"]) << " is "
-              << std::get<double>(context.variables["sum"]) << ".\n";
+              << std::get<LuaInteger>(context.variables["a"])
+              << " and " << std::get<LuaFloat>(context.variables["b"]) << " is "
+              << std::get<LuaFloat>(context.variables["sum"]) << ".\n";
 
     return 0;
 }

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -49,24 +49,13 @@ using LuaFloat = LUA_NUMBER; ///< The floating point type used by the Lua interp
 using LuaString = std::string; ///< The string type used by the Lua interpreter
 using LuaBool = bool; ///< The boolean type used by the Lua interpreter
 
-namespace StepVariable {
-    /**
-     * The types available to forward variables from one Step to the next.
-     */
-    using Integer = long long; ///< Storage type for integral numbers
-    using Float = double; ///< Storage type for floatingpoint number
-    using String = std::string; ///< Storage type for strings
-    using Bool = bool; ///< Storage type for booleans
-
-    /**
-     * One value holding any storage type
-     */
-    using Value = std::variant<
-        StepVariable::Integer,
-        StepVariable::Float,
-        StepVariable::String,
-        StepVariable::Bool>;
-}
+/**
+ * The types available to forward variables from one Step to the next.
+ */
+using VarInteger = long long; ///< Storage type for integral numbers
+using VarFloat = double; ///< Storage type for floatingpoint number
+using VarString = std::string; ///< Storage type for strings
+using VarBool = bool; ///< Storage type for booleans
 
 /**
  * A VariableValue is a variant over all Variable types.
@@ -77,7 +66,11 @@ namespace StepVariable {
  * Do not use a char* to pass the string, it might be converted to bool instead
  * of the expected std::string. The conversion depends on the used compiler (version).
  */
-using VariableValue = StepVariable::Value;
+using VariableValue = std::variant<
+    VarInteger,
+    VarFloat,
+    VarString,
+    VarBool>;
 
 /**
  * Associative table that holds Lua variable names and their value.

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -40,7 +40,17 @@
 namespace task {
 
 /**
- * A VariableValue is a variant over several data types Lua can understand (long long, double, std::string, bool).
+ * Lua uses certain types to interface with C++.
+ *
+ * If these types are used the data comes from or shall go to the Lua engine.
+ */
+using LuaInteger = LUA_INTEGER;
+using LuaFloat = LUA_NUMBER;
+using LuaString = std::string;
+using LuaBool = bool;
+
+/**
+ * A VariableValue is a variant over several data types Lua can understand.
  *
  * Variable names are associated with these values via a map in the Context class.
  *
@@ -48,7 +58,7 @@ namespace task {
  * Do not use a char* to pass the string, it might be converted to bool instead
  * of the expected std::string. The conversion depends on the used compiler (version).
  */
-using VariableValue = std::variant<long long, double, std::string, bool>;
+using VariableValue = std::variant<LuaInteger, LuaFloat, LuaString, LuaBool>;
 
 /**
  * Associative table that holds Lua variable names and their value.

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -44,10 +44,10 @@ namespace task {
  *
  * If these types are used the data comes from or shall go to the Lua engine.
  */
-using LuaInteger = LUA_INTEGER;
-using LuaFloat = LUA_NUMBER;
-using LuaString = std::string;
-using LuaBool = bool;
+using LuaInteger = LUA_INTEGER; ///< The integer type used by the Lua interpreter
+using LuaFloat = LUA_NUMBER; ///< The floating point type used by the Lua interpreter
+using LuaString = std::string; ///< The string type used by the Lua interpreter
+using LuaBool = bool; ///< The boolean type used by the Lua interpreter
 
 namespace StepVariable {
     /**

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -49,8 +49,27 @@ using LuaFloat = LUA_NUMBER;
 using LuaString = std::string;
 using LuaBool = bool;
 
+namespace StepVariable {
+    /**
+     * The types available to forward variables from one Step to the next.
+     */
+    using Integer = long long; ///< Storage type for integral numbers
+    using Float = double; ///< Storage type for floatingpoint number
+    using String = std::string; ///< Storage type for strings
+    using Bool = bool; ///< Storage type for booleans
+
+    /**
+     * One value holding any storage type
+     */
+    using Value = std::variant<
+        StepVariable::Integer,
+        StepVariable::Float,
+        StepVariable::String,
+        StepVariable::Bool>;
+}
+
 /**
- * A VariableValue is a variant over several data types Lua can understand.
+ * A VariableValue is a variant over all Variable types.
  *
  * Variable names are associated with these values via a map in the Context class.
  *
@@ -58,7 +77,7 @@ using LuaBool = bool;
  * Do not use a char* to pass the string, it might be converted to bool instead
  * of the expected std::string. The conversion depends on the used compiler (version).
  */
-using VariableValue = std::variant<LuaInteger, LuaFloat, LuaString, LuaBool>;
+using VariableValue = StepVariable::Value;
 
 /**
  * Associative table that holds Lua variable names and their value.

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -61,8 +61,8 @@ void Step::copy_used_variables_from_context_to_lua(const Context& context, sol::
             {
                 using T = std::decay_t<decltype(value)>;
 
-                if constexpr (std::is_same_v<T, double> or std::is_same_v<T, long long> or
-                              std::is_same_v<T, std::string> or std::is_same_v<T, bool>)
+                if constexpr (std::is_same_v<T, LuaFloat> or std::is_same_v<T, LuaInteger> or
+                              std::is_same_v<T, LuaString> or std::is_same_v<T, LuaBool>)
                 {
                     lua[varname_str] = value;
                 }
@@ -89,16 +89,16 @@ void Step::copy_used_variables_from_lua_to_context(const sol::state& lua, Contex
         {
             case sol::type::number:
                 // For this check to work, SOL_SAFE_NUMERICS needs to be set to 1
-                if (var.is<long long>())
-                    context.variables[varname] = VariableValue{ var.as<long long>() };
+                if (var.is<LuaInteger>())
+                    context.variables[varname] = VariableValue{ var.as<LuaInteger>() };
                 else
-                    context.variables[varname] = VariableValue{ var.as<double>() };
+                    context.variables[varname] = VariableValue{ var.as<LuaFloat>() };
                 break;
             case sol::type::string:
-                context.variables[varname] = VariableValue{ var.as<std::string>() };
+                context.variables[varname] = VariableValue{ var.as<LuaString>() };
                 break;
             case sol::type::boolean:
-                context.variables[varname] = VariableValue{ var.as<bool>() };
+                context.variables[varname] = VariableValue{ var.as<LuaBool>() };
                 break;
             case sol::type::lua_nil:
                 context.variables.erase(varname);

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -61,13 +61,13 @@ void Step::copy_used_variables_from_context_to_lua(const Context& context, sol::
             {
                 using T = std::decay_t<decltype(value)>;
 
-                if constexpr (std::is_same_v<T, StepVariable::Integer>)
+                if constexpr (std::is_same_v<T, VarInteger>)
                     lua[varname_str] = LuaInteger{ value };
-                else if constexpr (std::is_same_v<T, StepVariable::Float>)
+                else if constexpr (std::is_same_v<T, VarFloat>)
                     lua[varname_str] = LuaFloat{ value };
-                else if constexpr (std::is_same_v<T, StepVariable::String>)
+                else if constexpr (std::is_same_v<T, VarString>)
                     lua[varname_str] = LuaString{ value };
-                else if constexpr (std::is_same_v<T, StepVariable::Bool>)
+                else if constexpr (std::is_same_v<T, VarBool>)
                     lua[varname_str] = LuaBool{ value };
                 else
                     static_assert(always_false_v<T>, "Unhandled type in variable import");
@@ -88,15 +88,15 @@ void Step::copy_used_variables_from_lua_to_context(const sol::state& lua, Contex
             case sol::type::number:
                 // For this check to work, SOL_SAFE_NUMERICS needs to be set to 1
                 if (var.is<LuaInteger>())
-                    context.variables[varname] = StepVariable::Integer{ var.as<LuaInteger>() };
+                    context.variables[varname] = VarInteger{ var.as<LuaInteger>() };
                 else
-                    context.variables[varname] = StepVariable::Float{ var.as<LuaFloat>() };
+                    context.variables[varname] = VarFloat{ var.as<LuaFloat>() };
                 break;
             case sol::type::string:
-                context.variables[varname] = StepVariable::String{ var.as<LuaString>() };
+                context.variables[varname] = VarString{ var.as<LuaString>() };
                 break;
             case sol::type::boolean:
-                context.variables[varname] = StepVariable::Bool{ var.as<LuaBool>() };
+                context.variables[varname] = VarBool{ var.as<LuaBool>() };
                 break;
             case sol::type::lua_nil:
                 context.variables.erase(varname);

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -90,7 +90,7 @@ void check_script_timeout(lua_State* lua_state)
 
     const auto registry = lua.registry();
 
-    sol::optional<long long> timeout_ms = registry[step_timeout_ms_since_epoch_key];
+    sol::optional<LuaInteger> timeout_ms = registry[step_timeout_ms_since_epoch_key];
 
     if (not timeout_ms.has_value())
     {
@@ -102,7 +102,7 @@ void check_script_timeout(lua_State* lua_state)
         using std::chrono::milliseconds;
         using std::chrono::round;
 
-        const long long now_ms =
+        const LuaInteger now_ms =
             round<milliseconds>(Clock::now().time_since_epoch()).count();
 
         if (now_ms > *timeout_ms)
@@ -138,24 +138,24 @@ StepIndex get_step_idx_from_registry(lua_State* lua_state)
     return *opt_step_idx;
 }
 
-long long get_ms_since_epoch(TimePoint t0, std::chrono::milliseconds dt)
+LuaInteger get_ms_since_epoch(TimePoint t0, std::chrono::milliseconds dt)
 {
     using std::chrono::milliseconds;
     using std::chrono::round;
 
-    static_assert(std::numeric_limits<long long>::max()
+    static_assert(std::numeric_limits<LuaInteger>::max()
                   >= std::numeric_limits<TimePoint::rep>::max());
-    static_assert(std::numeric_limits<long long>::max()
+    static_assert(std::numeric_limits<LuaInteger>::max()
                   >= std::numeric_limits<milliseconds::rep>::max());
 
-    const long long t0_ms = round<milliseconds>(t0.time_since_epoch()).count();
-    const long long max_dt = std::numeric_limits<long long>::max() - t0_ms;
-    const long long dt_ms = dt.count();
+    const LuaInteger t0_ms = round<milliseconds>(t0.time_since_epoch()).count();
+    const LuaInteger max_dt = std::numeric_limits<LuaInteger>::max() - t0_ms;
+    const LuaInteger dt_ms = dt.count();
 
     if (dt_ms < max_dt)
         return t0_ms + dt_ms;
     else
-        return std::numeric_limits<long long>::max();
+        return std::numeric_limits<LuaInteger>::max();
 }
 
 void hook_check_timeout_and_termination_request(lua_State* lua_state, lua_Debug*)

--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -34,11 +34,11 @@
 #include "taskolib/CommChannel.h"
 #include "taskolib/Context.h"
 
-// Check that the lua lib has been build with the expected types
-static_assert(std::is_same<LUA_NUMBER, double>::value, "Unexpected Lua-internal floating point type");
-static_assert(std::is_same<LUA_INTEGER, long long>::value, "Unexpected Lua-internal integer type");
-
 namespace task {
+
+// Check that the lua lib has been build with the expected types
+static_assert(std::is_same<LuaFloat, double>::value, "Unexpected Lua-internal floating point type");
+static_assert(std::is_same<LuaInteger, long long>::value, "Unexpected Lua-internal integer type");
 
 // Abort the execution of the script by raising a LUA error with the given error message.
 void abort_script_with_error(lua_State* lua_state, const std::string& msg);
@@ -68,7 +68,7 @@ StepIndex get_step_idx_from_registry(lua_State* lua_state);
 // Return a time point in milliseconds since the epoch, calculated from a time point t0
 // plus a duration dt. In case of overflow, the maximum representable time point is
 // returned.
-long long get_ms_since_epoch(TimePoint t0, std::chrono::milliseconds dt);
+LuaInteger get_ms_since_epoch(TimePoint t0, std::chrono::milliseconds dt);
 
 // A LUA hook that stops the execution of the script by raising a LUA error.
 // This hook reinstalls itself so that it is called immediately if the execution should

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -82,8 +82,8 @@ TEST_CASE("Check context variable assignment", "[Context]")
     // Some compilers fill this into the bool alternative!
     // See PR #33 for details.
     c.variables["b"] = "BooleanTest"s; // assigns std::string
-    // or: c.variables["b"] = LuaString{ "BooleanTest"s };
-    REQUIRE(std::holds_alternative<LuaBool>(c.variables["b"]) == false);
-    REQUIRE(std::holds_alternative<LuaString>(c.variables["b"]) == true);
-    REQUIRE(std::get<LuaString>(c.variables["b"]) == "BooleanTest");
+    // or: c.variables["b"] = StepVariable::String{ "BooleanTest"s };
+    REQUIRE(std::holds_alternative<StepVariable::Bool>(c.variables["b"]) == false);
+    REQUIRE(std::holds_alternative<StepVariable::String>(c.variables["b"]) == true);
+    REQUIRE(std::get<StepVariable::String>(c.variables["b"]) == "BooleanTest");
 }

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -82,7 +82,8 @@ TEST_CASE("Check context variable assignment", "[Context]")
     // Some compilers fill this into the bool alternative!
     // See PR #33 for details.
     c.variables["b"] = "BooleanTest"s; // assigns std::string
-    REQUIRE(std::holds_alternative<bool>(c.variables["b"]) == false);
-    REQUIRE(std::holds_alternative<std::string>(c.variables["b"]) == true);
-    REQUIRE(std::get<std::string>(c.variables["b"]) == "BooleanTest");
+    // or: c.variables["b"] = LuaString{ "BooleanTest"s };
+    REQUIRE(std::holds_alternative<LuaBool>(c.variables["b"]) == false);
+    REQUIRE(std::holds_alternative<LuaString>(c.variables["b"]) == true);
+    REQUIRE(std::get<LuaString>(c.variables["b"]) == "BooleanTest");
 }

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -82,8 +82,8 @@ TEST_CASE("Check context variable assignment", "[Context]")
     // Some compilers fill this into the bool alternative!
     // See PR #33 for details.
     c.variables["b"] = "BooleanTest"s; // assigns std::string
-    // or: c.variables["b"] = StepVariable::String{ "BooleanTest"s };
-    REQUIRE(std::holds_alternative<StepVariable::Bool>(c.variables["b"]) == false);
-    REQUIRE(std::holds_alternative<StepVariable::String>(c.variables["b"]) == true);
-    REQUIRE(std::get<StepVariable::String>(c.variables["b"]) == "BooleanTest");
+    // or: c.variables["b"] = VarString{ "BooleanTest"s };
+    REQUIRE(std::holds_alternative<VarBool>(c.variables["b"]) == false);
+    REQUIRE(std::holds_alternative<VarString>(c.variables["b"]) == true);
+    REQUIRE(std::get<VarString>(c.variables["b"]) == "BooleanTest");
 }

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -293,7 +293,7 @@ TEST_CASE("Executor: Redirection of print() output", "[Executor]")
 TEST_CASE("Executor: Access context after run", "[Executor]")
 {
     Context ctx;
-    ctx.variables["a"] = LuaInteger{ 1 };
+    ctx.variables["a"] = StepVariable::Integer{ 1 };
 
     Sequence seq{ "a Seq" };
     seq.push_back(Step{ Step::type_while  }.set_script("return a % 10 ~= 0"));
@@ -306,7 +306,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
 
     // Execute directly
     seq.execute(ctx, nullptr);
-    REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 11 );
+    REQUIRE(std::get<StepVariable::Integer>(ctx.variables["a"]) == 11 );
 
     // Execute async
     Executor executor{ };
@@ -314,7 +314,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
     while (executor.update(seq))
         gul14::sleep(5ms);
     auto vars = executor.get_context_variables();
-    REQUIRE(std::get<LuaInteger>(vars["a"]) == 21);
+    REQUIRE(std::get<StepVariable::Integer>(vars["a"]) == 21);
 }
 
 TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
@@ -348,7 +348,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
 
     step_while_end.set_label("end loop");
 
-    ctx.variables["a"] = LuaInteger{ 0 };
+    ctx.variables["a"] = StepVariable::Integer{ 0 };
 
     seq.push_back(step_while);
     seq.push_back(step_increment);

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -293,7 +293,7 @@ TEST_CASE("Executor: Redirection of print() output", "[Executor]")
 TEST_CASE("Executor: Access context after run", "[Executor]")
 {
     Context ctx;
-    ctx.variables["a"] = StepVariable::Integer{ 1 };
+    ctx.variables["a"] = VarInteger{ 1 };
 
     Sequence seq{ "a Seq" };
     seq.push_back(Step{ Step::type_while  }.set_script("return a % 10 ~= 0"));
@@ -306,7 +306,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
 
     // Execute directly
     seq.execute(ctx, nullptr);
-    REQUIRE(std::get<StepVariable::Integer>(ctx.variables["a"]) == 11 );
+    REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 11 );
 
     // Execute async
     Executor executor{ };
@@ -314,7 +314,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
     while (executor.update(seq))
         gul14::sleep(5ms);
     auto vars = executor.get_context_variables();
-    REQUIRE(std::get<StepVariable::Integer>(vars["a"]) == 21);
+    REQUIRE(std::get<VarInteger>(vars["a"]) == 21);
 }
 
 TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
@@ -348,7 +348,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
 
     step_while_end.set_label("end loop");
 
-    ctx.variables["a"] = StepVariable::Integer{ 0 };
+    ctx.variables["a"] = VarInteger{ 0 };
 
     seq.push_back(step_while);
     seq.push_back(step_increment);

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -293,7 +293,7 @@ TEST_CASE("Executor: Redirection of print() output", "[Executor]")
 TEST_CASE("Executor: Access context after run", "[Executor]")
 {
     Context ctx;
-    ctx.variables["a"] = VariableValue{ 1LL };
+    ctx.variables["a"] = LuaInteger{ 1 };
 
     Sequence seq{ "a Seq" };
     seq.push_back(Step{ Step::type_while  }.set_script("return a % 10 ~= 0"));
@@ -306,7 +306,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
 
     // Execute directly
     seq.execute(ctx, nullptr);
-    REQUIRE(std::get<long long>(ctx.variables["a"] ) == 11LL );
+    REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 11 );
 
     // Execute async
     Executor executor{ };
@@ -314,7 +314,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
     while (executor.update(seq))
         gul14::sleep(5ms);
     auto vars = executor.get_context_variables();
-    REQUIRE(std::get<long long>(vars["a"]) == 21LL);
+    REQUIRE(std::get<LuaInteger>(vars["a"]) == 21);
 }
 
 TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
@@ -348,7 +348,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
 
     step_while_end.set_label("end loop");
 
-    ctx.variables["a"] = VariableValue{ 0LL };
+    ctx.variables["a"] = LuaInteger{ 0 };
 
     seq.push_back(step_while);
     seq.push_back(step_increment);

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -26,6 +26,7 @@
 #include "taskolib/Sequence.h"
 
 using namespace task;
+using namespace task::StepVariable;
 using namespace std::literals;
 
 TEST_CASE("Sequence: Constructor without descriptive label", "[Sequence]")
@@ -1134,7 +1135,7 @@ TEST_CASE("execute(): simple sequence", "[Sequence]")
 TEST_CASE("execute(): Simple sequence with unchanged context", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     Step step;
     step.set_used_context_variable_names(VariableNames{"a"});
@@ -1144,13 +1145,13 @@ TEST_CASE("execute(): Simple sequence with unchanged context", "[Sequence]")
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() == "");
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 0);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 0);
 }
 
 TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]")
 {
     Context ctx;
-    ctx.variables["a"] = LuaInteger{ 0 };
+    ctx.variables["a"] = Integer{ 0 };
     Sequence seq("Simple sequence");
 
     SECTION("Dont manipulate context variable") {
@@ -1159,7 +1160,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 0);
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 0);
     }
     SECTION("Manipulate context variable") {
         Step s1;
@@ -1168,7 +1169,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over (not)") {
         Step s1;
@@ -1180,7 +1181,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over") {
         Step s1;
@@ -1193,7 +1194,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand variable over context without initial value") {
         Step s1;
@@ -1206,7 +1207,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand bool variable over context without initial value") {
         Step s1;
@@ -1219,8 +1220,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<LuaInteger>(ctx.variables["a"]));
-        REQUIRE(ctx.variables["a"] == VariableValue{ LuaInteger{ 4 } }); // Another variant to check variables
+        CAPTURE(std::get<Integer>(ctx.variables["a"]));
+        REQUIRE(ctx.variables["a"] == VariableValue{ Integer{ 4 }}); // Another variant to check variables
     }
     SECTION("Hand nil variable over context without initial value") {
         Step s1;
@@ -1237,8 +1238,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s2);
         seq.push_back(s3);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<LuaInteger>(ctx.variables["a"]));
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
+        CAPTURE(std::get<Integer>(ctx.variables["a"]));
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
     }
     SECTION("Check nil is really non-existing") {
@@ -1265,8 +1266,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s3);
         seq.push_back(s4);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<LuaInteger>(ctx.variables["a"]));
-        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 1);
+        CAPTURE(std::get<Integer>(ctx.variables["a"]));
+        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 1);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
     }
 }
@@ -1291,7 +1292,7 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
           "change", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = LuaInteger{ 1 };
+    context.variables["a"] = Integer{ 1 };
 
     Step step_action1;
     step_action1.set_label("Action");
@@ -1309,13 +1310,13 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
 
     REQUIRE_THROWS(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() != "");
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 1);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 1);
 }
 
 TEST_CASE("execute(): complex sequence with context change", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = LuaInteger{ 1 };
+    context.variables["a"] = Integer{ 1 };
 
     Step step_action1;
     step_action1.set_label("Action1");
@@ -1328,7 +1329,7 @@ TEST_CASE("execute(): complex sequence with context change", "[Sequence]")
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() == "");
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): if-else sequence", "[Sequence]")
@@ -1382,19 +1383,19 @@ TEST_CASE("execute(): if-else sequence", "[Sequence]")
     SECTION("if-else sequence with if=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
     }
 
     SECTION("if-else sequence with if=false")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
     }
 }
 
@@ -1449,28 +1450,28 @@ TEST_CASE("execute(): if-elseif sequence", "[Sequence]")
     SECTION("if-elseif sequence with if=elseif=false")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["a"] = Integer{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 0);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 0);
     }
 
     SECTION("if-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif sequence with elseif=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
     }
 }
 
@@ -1539,28 +1540,28 @@ TEST_CASE("execute(): if-elseif-else sequence", "[Sequence]")
     SECTION("if-elseif-else sequence with if=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-else sequence with elseif=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-else sequence with else=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 3 };
+        context.variables["a"] = Integer{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
     }
 }
 
@@ -1629,37 +1630,37 @@ TEST_CASE("execute(): if-elseif-elseif sequence", "[Sequence]")
     SECTION("if-elseif-elseif sequence with if=elseif=elseif=false")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["a"] = Integer{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 0);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 0);
     }
 
     SECTION("if-elseif-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[1]=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[2]=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 3 };
+        context.variables["a"] = Integer{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
     }
 }
 
@@ -1741,37 +1742,37 @@ TEST_CASE("execute(): if-elseif-elseif-else sequence", "[Sequence]")
     SECTION("if-elseif-elseif sequence with if=elseif=elseif=false")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["a"] = Integer{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 5);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 5);
     }
 
     SECTION("if-elseif-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[1]=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[2]=true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 3 };
+        context.variables["a"] = Integer{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
     }
 }
 
@@ -1825,28 +1826,28 @@ TEST_CASE("execute(): if-elseif-else-end sequence with empty blocks", "[Sequence
     SECTION("IF condition true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 1 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("First ELSEIF condition true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 2 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("Second ELSEIF condition true")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 3 };
+        context.variables["a"] = Integer{ 3 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("All conditions false, use ELSE branch")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 4 };
+        context.variables["a"] = Integer{ 4 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 }
@@ -1913,7 +1914,7 @@ TEST_CASE("execute(): faulty if-else-elseif sequence", "[Sequence]")
     sequence.push_back(step_if_end);
 
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     REQUIRE(sequence.get_error_message() == "");
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
@@ -1957,10 +1958,10 @@ TEST_CASE("execute(): while sequence", "[Sequence]")
     SECTION("while sequence with while: a<10")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["a"] = Integer{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
     }
 }
 
@@ -1994,10 +1995,10 @@ TEST_CASE("execute(): empty while sequence", "[Sequence]")
     SECTION("while sequence with while: a<10")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["a"] = Integer{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
     }
 }
 
@@ -2046,10 +2047,10 @@ TEST_CASE("execute(): try sequence with success", "[Sequence]")
     sequence.push_back(step_try_end);
 
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 1);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 1);
 }
 
 TEST_CASE("execute(): try sequence with fault", "[Sequence]")
@@ -2104,10 +2105,10 @@ TEST_CASE("execute(): try sequence with fault", "[Sequence]")
     sequence.push_back(step_try_end);
 
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex try sequence with nested fault condition",
@@ -2196,10 +2197,10 @@ TEST_CASE("execute(): complex try sequence with nested fault condition",
     sequence.push_back(step_10);
 
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
 }
 
 TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
@@ -2262,11 +2263,11 @@ TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
     sequence.push_back(step_06);
 
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
     REQUIRE(sequence.get_error_message() != "");
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
@@ -2362,7 +2363,7 @@ TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
 
     Context context;
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
-    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex sequence", "[Sequence]")
@@ -2623,89 +2624,89 @@ TEST_CASE("execute(): complex sequence", "[Sequence]")
     {
         Context context;
         // a=0, b=0, c=0, d=0/1/2, e=1/2/3, f=0, g=2/1
-        context.variables["a"] = LuaInteger{ 0 };
-        context.variables["b"] = LuaInteger{ 0 };
-        context.variables["c"] = LuaInteger{ 0 };
-        context.variables["d"] = LuaInteger{ 0 };
-        context.variables["e"] = LuaInteger{ 1 };
-        context.variables["f"] = LuaInteger{ 1 };
-        context.variables["g"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 0 };
+        context.variables["b"] = Integer{ 0 };
+        context.variables["c"] = Integer{ 0 };
+        context.variables["d"] = Integer{ 0 };
+        context.variables["e"] = Integer{ 1 };
+        context.variables["f"] = Integer{ 1 };
+        context.variables["g"] = Integer{ 1 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
 
         // a=10, b=1, c=1, d=0/2/3, e=1/3/4, f=2, g=1/2
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
-        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 0);
-        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 1); // not touched
-        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 1); // not touched
-        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 1); // not touched
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
+        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["d"]) == 0);
+        REQUIRE(std::get<Integer>(context.variables["e"]) == 1); // not touched
+        REQUIRE(std::get<Integer>(context.variables["f"]) == 1); // not touched
+        REQUIRE(std::get<Integer>(context.variables["g"]) == 1); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 1->3, e: 1->2, f: 1->1, "
             "g: 1->1")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
-        context.variables["b"] = LuaInteger{ 0 };
-        context.variables["c"] = LuaInteger{ 0 };
-        context.variables["d"] = LuaInteger{ 1 };
-        context.variables["e"] = LuaInteger{ 1 };
-        context.variables["f"] = LuaInteger{ 1 };
-        context.variables["g"] = LuaInteger{ 1 };
+        context.variables["a"] = Integer{ 0 };
+        context.variables["b"] = Integer{ 0 };
+        context.variables["c"] = Integer{ 0 };
+        context.variables["d"] = Integer{ 1 };
+        context.variables["e"] = Integer{ 1 };
+        context.variables["f"] = Integer{ 1 };
+        context.variables["g"] = Integer{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
-        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 3);
-        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 2);
-        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 1); // not touched
-        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 1); // not touched
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
+        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["d"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["e"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["f"]) == 1); // not touched
+        REQUIRE(std::get<Integer>(context.variables["g"]) == 1); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 2->3, e: 5->5, f: 2->2, "
             "g: 3->3")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
-        context.variables["b"] = LuaInteger{ 0 };
-        context.variables["c"] = LuaInteger{ 1 };
-        context.variables["d"] = LuaInteger{ 2 };
-        context.variables["e"] = LuaInteger{ 5 };
-        context.variables["f"] = LuaInteger{ 3 };
-        context.variables["g"] = LuaInteger{ 2 };
+        context.variables["a"] = Integer{ 0 };
+        context.variables["b"] = Integer{ 0 };
+        context.variables["c"] = Integer{ 1 };
+        context.variables["d"] = Integer{ 2 };
+        context.variables["e"] = Integer{ 5 };
+        context.variables["f"] = Integer{ 3 };
+        context.variables["g"] = Integer{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
-        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 3);
-        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 5); // not touched
-        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 3); // not touched
-        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 2); // not touched
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
+        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["d"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["e"]) == 5); // not touched
+        REQUIRE(std::get<Integer>(context.variables["f"]) == 3); // not touched
+        REQUIRE(std::get<Integer>(context.variables["g"]) == 2); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 1->3, e: 2->4, f: 3->2, "
             "g: 4->2")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 0 };
-        context.variables["b"] = LuaInteger{ 0 };
-        context.variables["c"] = LuaInteger{ 1 };
-        context.variables["d"] = LuaInteger{ 1 };
-        context.variables["e"] = LuaInteger{ 2 };
-        context.variables["f"] = LuaInteger{ 3 };
-        context.variables["g"] = LuaInteger{ 4 };
+        context.variables["a"] = Integer{ 0 };
+        context.variables["b"] = Integer{ 0 };
+        context.variables["c"] = Integer{ 1 };
+        context.variables["d"] = Integer{ 1 };
+        context.variables["e"] = Integer{ 2 };
+        context.variables["f"] = Integer{ 3 };
+        context.variables["g"] = Integer{ 4 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
-        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 3);
-        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 3);
-        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 3); // not touched
-        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 4); // not touched
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
+        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["d"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["e"]) == 3);
+        REQUIRE(std::get<Integer>(context.variables["f"]) == 3); // not touched
+        REQUIRE(std::get<Integer>(context.variables["g"]) == 4); // not touched
     }
 }
 
@@ -2870,7 +2871,7 @@ TEST_CASE("execute_sequence(): Messages", "[execute_sequence]")
     auto& queue = comm.queue_;
 
     Context context;
-    context.variables["a"] = LuaInteger{ 0 };
+    context.variables["a"] = Integer{ 0 };
 
     Step step1{ Step::type_action };
     step1.set_used_context_variable_names(VariableNames{ "a" });
@@ -2998,11 +2999,11 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     SECTION("All steps enabled")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 5 };
+        context.variables["a"] = Integer{ 5 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
-        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
     }
 
     sequence.modify(sequence.begin() + 1, [](Step& s) {
@@ -3013,11 +3014,11 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     SECTION("Second step disabled")
     {
         Context context;
-        context.variables["a"] = LuaInteger{ 5 };
+        context.variables["a"] = Integer{ 5 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 1);
-        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 1);
+        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
     }
 }
 
@@ -3045,7 +3046,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 6);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 6);
     }
 
     sequence.modify(sequence.begin() + 1, [](Step& s) {
@@ -3056,7 +3057,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 5);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 5);
     }
 
     sequence.modify(sequence.begin() + 2, [](Step& s) {
@@ -3067,7 +3068,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
+        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
     }
 }
 
@@ -3145,7 +3146,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = LuaInteger{ 5 };
+        context.variables["a"] = Integer{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == true);
@@ -3172,7 +3173,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = LuaInteger{ 5 };
+        context.variables["a"] = Integer{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == false);
@@ -3199,7 +3200,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = LuaInteger{ 5 };
+        context.variables["a"] = Integer{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == false);
@@ -3283,7 +3284,7 @@ TEST_CASE("execute(): disable 'invariant' (afterwards)", "[Sequence]")
     sequence.push_back(step_post); // b = 1
 
     Context context;
-    context.variables["a"] = LuaInteger{ 5 };
+    context.variables["a"] = Integer{ 5 };
 
     SECTION("Second step disabled")
     {
@@ -3543,7 +3544,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
 
     step_while_end.set_label("end loop");
 
-    ctx.variables["a"] = LuaInteger{ 0 };
+    ctx.variables["a"] = Integer{ 0 };
 
     seq.push_back(step_while);
     seq.push_back(step_increment);
@@ -3557,7 +3558,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
     for (const auto& step : seq)
         REQUIRE(step.is_running() == false);
 
-    REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
+    REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
     REQUIRE(not queue.empty());
     REQUIRE(queue.size() == 26);
     auto msg = queue.back();

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -1134,7 +1134,7 @@ TEST_CASE("execute(): simple sequence", "[Sequence]")
 TEST_CASE("execute(): Simple sequence with unchanged context", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
+    context.variables["a"] = LuaInteger{ 0 };
 
     Step step;
     step.set_used_context_variable_names(VariableNames{"a"});
@@ -1144,13 +1144,13 @@ TEST_CASE("execute(): Simple sequence with unchanged context", "[Sequence]")
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() == "");
-    REQUIRE(context.variables["a"] == VariableValue{ 0LL } );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 0);
 }
 
 TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]")
 {
     Context ctx;
-    ctx.variables["a"] = VariableValue{ 0LL };
+    ctx.variables["a"] = LuaInteger{ 0 };
     Sequence seq("Simple sequence");
 
     SECTION("Dont manipulate context variable") {
@@ -1159,7 +1159,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.execute(ctx, nullptr);
-        REQUIRE(ctx.variables["a"] == VariableValue{ 0LL } );
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 0);
     }
     SECTION("Manipulate context variable") {
         Step s1;
@@ -1168,7 +1168,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.execute(ctx, nullptr);
-        REQUIRE(ctx.variables["a"] == VariableValue{ 2LL } );
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over (not)") {
         Step s1;
@@ -1180,7 +1180,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(ctx.variables["a"] == VariableValue{ 2LL } );
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over") {
         Step s1;
@@ -1193,7 +1193,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand variable over context without initial value") {
         Step s1;
@@ -1206,7 +1206,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand bool variable over context without initial value") {
         Step s1;
@@ -1219,8 +1219,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<long long>(ctx.variables["a"]));
-        REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
+        CAPTURE(std::get<LuaInteger>(ctx.variables["a"]));
+        REQUIRE(ctx.variables["a"] == VariableValue{ LuaInteger{ 4 } }); // Another variant to check variables
     }
     SECTION("Hand nil variable over context without initial value") {
         Step s1;
@@ -1237,8 +1237,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s2);
         seq.push_back(s3);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<long long>(ctx.variables["a"]));
-        REQUIRE(ctx.variables["a"] == VariableValue{ 4LL } );
+        CAPTURE(std::get<LuaInteger>(ctx.variables["a"]));
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
     }
     SECTION("Check nil is really non-existing") {
@@ -1265,8 +1265,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s3);
         seq.push_back(s4);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<long long>(ctx.variables["a"]));
-        REQUIRE(ctx.variables["a"] == VariableValue{ 1LL } );
+        CAPTURE(std::get<LuaInteger>(ctx.variables["a"]));
+        REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 1);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
     }
 }
@@ -1291,7 +1291,7 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
           "change", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = VariableValue{ 1LL };
+    context.variables["a"] = LuaInteger{ 1 };
 
     Step step_action1;
     step_action1.set_label("Action");
@@ -1309,13 +1309,13 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
 
     REQUIRE_THROWS(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() != "");
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 1LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 1);
 }
 
 TEST_CASE("execute(): complex sequence with context change", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = VariableValue{ 1LL };
+    context.variables["a"] = LuaInteger{ 1 };
 
     Step step_action1;
     step_action1.set_label("Action1");
@@ -1328,7 +1328,7 @@ TEST_CASE("execute(): complex sequence with context change", "[Sequence]")
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() == "");
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): if-else sequence", "[Sequence]")
@@ -1382,19 +1382,19 @@ TEST_CASE("execute(): if-else sequence", "[Sequence]")
     SECTION("if-else sequence with if=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 1LL };
+        context.variables["a"] = LuaInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-else sequence with if=false")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 2LL };
+        context.variables["a"] = LuaInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 3LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
     }
 }
 
@@ -1449,28 +1449,28 @@ TEST_CASE("execute(): if-elseif sequence", "[Sequence]")
     SECTION("if-elseif sequence with if=elseif=false")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 0LL };
+        context.variables["a"] = LuaInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 0LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 0);
     }
 
     SECTION("if-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 1LL };
+        context.variables["a"] = LuaInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif sequence with elseif=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 2LL };
+        context.variables["a"] = LuaInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 3LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
     }
 }
 
@@ -1539,28 +1539,28 @@ TEST_CASE("execute(): if-elseif-else sequence", "[Sequence]")
     SECTION("if-elseif-else sequence with if=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 1LL };
+        context.variables["a"] = LuaInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-else sequence with elseif=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 2LL };
+        context.variables["a"] = LuaInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 3LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-else sequence with else=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 3LL };
+        context.variables["a"] = LuaInteger{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 4LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -1629,37 +1629,37 @@ TEST_CASE("execute(): if-elseif-elseif sequence", "[Sequence]")
     SECTION("if-elseif-elseif sequence with if=elseif=elseif=false")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 0LL };
+        context.variables["a"] = LuaInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 0LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 0);
     }
 
     SECTION("if-elseif-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 1LL };
+        context.variables["a"] = LuaInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[1]=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 2LL };
+        context.variables["a"] = LuaInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 3LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[2]=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 3LL };
+        context.variables["a"] = LuaInteger{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 4LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -1741,37 +1741,37 @@ TEST_CASE("execute(): if-elseif-elseif-else sequence", "[Sequence]")
     SECTION("if-elseif-elseif sequence with if=elseif=elseif=false")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 0LL };
+        context.variables["a"] = LuaInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 5LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 5);
     }
 
     SECTION("if-elseif-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 1LL };
+        context.variables["a"] = LuaInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[1]=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 2LL };
+        context.variables["a"] = LuaInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 3LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[2]=true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 3LL };
+        context.variables["a"] = LuaInteger{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 4LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -1825,28 +1825,28 @@ TEST_CASE("execute(): if-elseif-else-end sequence with empty blocks", "[Sequence
     SECTION("IF condition true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 1LL };
+        context.variables["a"] = LuaInteger{ 1 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("First ELSEIF condition true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 2LL };
+        context.variables["a"] = LuaInteger{ 2 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("Second ELSEIF condition true")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 3LL };
+        context.variables["a"] = LuaInteger{ 3 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("All conditions false, use ELSE branch")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 4LL };
+        context.variables["a"] = LuaInteger{ 4 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 }
@@ -1913,7 +1913,7 @@ TEST_CASE("execute(): faulty if-else-elseif sequence", "[Sequence]")
     sequence.push_back(step_if_end);
 
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
+    context.variables["a"] = LuaInteger{ 0 };
 
     REQUIRE(sequence.get_error_message() == "");
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
@@ -1957,10 +1957,10 @@ TEST_CASE("execute(): while sequence", "[Sequence]")
     SECTION("while sequence with while: a<10")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 0LL };
+        context.variables["a"] = LuaInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 10LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
     }
 }
 
@@ -1994,10 +1994,10 @@ TEST_CASE("execute(): empty while sequence", "[Sequence]")
     SECTION("while sequence with while: a<10")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 0LL };
+        context.variables["a"] = LuaInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 10LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
     }
 }
 
@@ -2046,10 +2046,10 @@ TEST_CASE("execute(): try sequence with success", "[Sequence]")
     sequence.push_back(step_try_end);
 
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
+    context.variables["a"] = LuaInteger{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 1LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 1);
 }
 
 TEST_CASE("execute(): try sequence with fault", "[Sequence]")
@@ -2104,10 +2104,10 @@ TEST_CASE("execute(): try sequence with fault", "[Sequence]")
     sequence.push_back(step_try_end);
 
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
+    context.variables["a"] = LuaInteger{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex try sequence with nested fault condition",
@@ -2196,10 +2196,10 @@ TEST_CASE("execute(): complex try sequence with nested fault condition",
     sequence.push_back(step_10);
 
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
+    context.variables["a"] = LuaInteger{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 3LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 3);
 }
 
 TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
@@ -2262,11 +2262,11 @@ TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
     sequence.push_back(step_06);
 
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
+    context.variables["a"] = LuaInteger{ 0 };
 
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
     REQUIRE(sequence.get_error_message() != "");
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
@@ -2361,10 +2361,8 @@ TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
     sequence.push_back(step_11);
 
     Context context;
-    context.variables["a"] = VariableValue{ 0LL };
-
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
-    REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
+    REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex sequence", "[Sequence]")
@@ -2625,89 +2623,89 @@ TEST_CASE("execute(): complex sequence", "[Sequence]")
     {
         Context context;
         // a=0, b=0, c=0, d=0/1/2, e=1/2/3, f=0, g=2/1
-        context.variables["a"] = VariableValue{0LL};
-        context.variables["b"] = VariableValue{0LL};
-        context.variables["c"] = VariableValue{0LL};
-        context.variables["d"] = VariableValue{0LL};
-        context.variables["e"] = VariableValue{1LL};
-        context.variables["f"] = VariableValue{1LL};
-        context.variables["g"] = VariableValue{1LL};
+        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["b"] = LuaInteger{ 0 };
+        context.variables["c"] = LuaInteger{ 0 };
+        context.variables["d"] = LuaInteger{ 0 };
+        context.variables["e"] = LuaInteger{ 1 };
+        context.variables["f"] = LuaInteger{ 1 };
+        context.variables["g"] = LuaInteger{ 1 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
 
         // a=10, b=1, c=1, d=0/2/3, e=1/3/4, f=2, g=1/2
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 10LL );
-        REQUIRE(std::get<long long>(context.variables["b"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["c"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["d"] ) == 0LL );
-        REQUIRE(std::get<long long>(context.variables["e"] ) == 1LL ); // not touched
-        REQUIRE(std::get<long long>(context.variables["f"] ) == 1LL ); // not touched
-        REQUIRE(std::get<long long>(context.variables["g"] ) == 1LL ); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 0);
+        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 1); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 1); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 1); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 1->3, e: 1->2, f: 1->1, "
             "g: 1->1")
     {
         Context context;
-        context.variables["a"] = VariableValue{0LL};
-        context.variables["b"] = VariableValue{0LL};
-        context.variables["c"] = VariableValue{0LL};
-        context.variables["d"] = VariableValue{1LL};
-        context.variables["e"] = VariableValue{1LL};
-        context.variables["f"] = VariableValue{1LL};
-        context.variables["g"] = VariableValue{1LL};
+        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["b"] = LuaInteger{ 0 };
+        context.variables["c"] = LuaInteger{ 0 };
+        context.variables["d"] = LuaInteger{ 1 };
+        context.variables["e"] = LuaInteger{ 1 };
+        context.variables["f"] = LuaInteger{ 1 };
+        context.variables["g"] = LuaInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 10LL );
-        REQUIRE(std::get<long long>(context.variables["b"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["c"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["d"] ) == 3LL );
-        REQUIRE(std::get<long long>(context.variables["e"] ) == 2LL );
-        REQUIRE(std::get<long long>(context.variables["f"] ) == 1LL ); // not touched
-        REQUIRE(std::get<long long>(context.variables["g"] ) == 1LL ); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 3);
+        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 2);
+        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 1); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 1); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 2->3, e: 5->5, f: 2->2, "
             "g: 3->3")
     {
         Context context;
-        context.variables["a"] = VariableValue{0LL};
-        context.variables["b"] = VariableValue{0LL};
-        context.variables["c"] = VariableValue{1LL};
-        context.variables["d"] = VariableValue{2LL};
-        context.variables["e"] = VariableValue{5LL};
-        context.variables["f"] = VariableValue{3LL};
-        context.variables["g"] = VariableValue{2LL};
+        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["b"] = LuaInteger{ 0 };
+        context.variables["c"] = LuaInteger{ 1 };
+        context.variables["d"] = LuaInteger{ 2 };
+        context.variables["e"] = LuaInteger{ 5 };
+        context.variables["f"] = LuaInteger{ 3 };
+        context.variables["g"] = LuaInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 10LL );
-        REQUIRE(std::get<long long>(context.variables["b"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["c"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["d"] ) == 3LL );
-        REQUIRE(std::get<long long>(context.variables["e"] ) == 5LL ); // not touched
-        REQUIRE(std::get<long long>(context.variables["f"] ) == 3LL ); // not touched
-        REQUIRE(std::get<long long>(context.variables["g"] ) == 2LL ); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 3);
+        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 5); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 3); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 2); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 1->3, e: 2->4, f: 3->2, "
             "g: 4->2")
     {
         Context context;
-        context.variables["a"] = VariableValue{0LL};
-        context.variables["b"] = VariableValue{0LL};
-        context.variables["c"] = VariableValue{1LL};
-        context.variables["d"] = VariableValue{1LL};
-        context.variables["e"] = VariableValue{2LL};
-        context.variables["f"] = VariableValue{3LL};
-        context.variables["g"] = VariableValue{4LL};
+        context.variables["a"] = LuaInteger{ 0 };
+        context.variables["b"] = LuaInteger{ 0 };
+        context.variables["c"] = LuaInteger{ 1 };
+        context.variables["d"] = LuaInteger{ 1 };
+        context.variables["e"] = LuaInteger{ 2 };
+        context.variables["f"] = LuaInteger{ 3 };
+        context.variables["g"] = LuaInteger{ 4 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 10LL );
-        REQUIRE(std::get<long long>(context.variables["b"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["c"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["d"] ) == 3LL );
-        REQUIRE(std::get<long long>(context.variables["e"] ) == 3LL );
-        REQUIRE(std::get<long long>(context.variables["f"] ) == 3LL ); // not touched
-        REQUIRE(std::get<long long>(context.variables["g"] ) == 4LL ); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["d"]) == 3);
+        REQUIRE(std::get<LuaInteger>(context.variables["e"]) == 3);
+        REQUIRE(std::get<LuaInteger>(context.variables["f"]) == 3); // not touched
+        REQUIRE(std::get<LuaInteger>(context.variables["g"]) == 4); // not touched
     }
 }
 
@@ -2872,7 +2870,7 @@ TEST_CASE("execute_sequence(): Messages", "[execute_sequence]")
     auto& queue = comm.queue_;
 
     Context context;
-    context.variables["a"] = 0LL;
+    context.variables["a"] = LuaInteger{ 0 };
 
     Step step1{ Step::type_action };
     step1.set_used_context_variable_names(VariableNames{ "a" });
@@ -3000,11 +2998,11 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     SECTION("All steps enabled")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 5LL };
+        context.variables["a"] = LuaInteger{ 5 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 2LL );
-        REQUIRE(std::get<long long>(context.variables["b"] ) == 1LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
     }
 
     sequence.modify(sequence.begin() + 1, [](Step& s) {
@@ -3015,11 +3013,11 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     SECTION("Second step disabled")
     {
         Context context;
-        context.variables["a"] = VariableValue{ 5LL };
+        context.variables["a"] = LuaInteger{ 5 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 1LL );
-        REQUIRE(std::get<long long>(context.variables["b"] ) == 1LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 1);
+        REQUIRE(std::get<LuaInteger>(context.variables["b"]) == 1);
     }
 }
 
@@ -3047,7 +3045,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 6LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 6);
     }
 
     sequence.modify(sequence.begin() + 1, [](Step& s) {
@@ -3058,7 +3056,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 5LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 5);
     }
 
     sequence.modify(sequence.begin() + 2, [](Step& s) {
@@ -3069,7 +3067,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<long long>(context.variables["a"] ) == 4LL );
+        REQUIRE(std::get<LuaInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -3147,7 +3145,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = VariableValue{ 5LL };
+        context.variables["a"] = LuaInteger{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == true);
@@ -3174,7 +3172,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = VariableValue{ 5LL };
+        context.variables["a"] = LuaInteger{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == false);
@@ -3201,7 +3199,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = VariableValue{ 5LL };
+        context.variables["a"] = LuaInteger{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == false);
@@ -3285,7 +3283,7 @@ TEST_CASE("execute(): disable 'invariant' (afterwards)", "[Sequence]")
     sequence.push_back(step_post); // b = 1
 
     Context context;
-    context.variables["a"] = VariableValue{ 5LL };
+    context.variables["a"] = LuaInteger{ 5 };
 
     SECTION("Second step disabled")
     {
@@ -3545,7 +3543,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
 
     step_while_end.set_label("end loop");
 
-    ctx.variables["a"] = VariableValue{ 0LL };
+    ctx.variables["a"] = LuaInteger{ 0 };
 
     seq.push_back(step_while);
     seq.push_back(step_increment);
@@ -3559,7 +3557,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
     for (const auto& step : seq)
         REQUIRE(step.is_running() == false);
 
-    REQUIRE(std::get<long long>(ctx.variables["a"] ) == 4LL);
+    REQUIRE(std::get<LuaInteger>(ctx.variables["a"]) == 4);
     REQUIRE(not queue.empty());
     REQUIRE(queue.size() == 26);
     auto msg = queue.back();

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -26,7 +26,6 @@
 #include "taskolib/Sequence.h"
 
 using namespace task;
-using namespace task::StepVariable;
 using namespace std::literals;
 
 TEST_CASE("Sequence: Constructor without descriptive label", "[Sequence]")
@@ -1135,7 +1134,7 @@ TEST_CASE("execute(): simple sequence", "[Sequence]")
 TEST_CASE("execute(): Simple sequence with unchanged context", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     Step step;
     step.set_used_context_variable_names(VariableNames{"a"});
@@ -1145,13 +1144,13 @@ TEST_CASE("execute(): Simple sequence with unchanged context", "[Sequence]")
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() == "");
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 0);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 0);
 }
 
 TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]")
 {
     Context ctx;
-    ctx.variables["a"] = Integer{ 0 };
+    ctx.variables["a"] = VarInteger{ 0 };
     Sequence seq("Simple sequence");
 
     SECTION("Dont manipulate context variable") {
@@ -1160,7 +1159,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 0);
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 0);
     }
     SECTION("Manipulate context variable") {
         Step s1;
@@ -1169,7 +1168,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over (not)") {
         Step s1;
@@ -1181,7 +1180,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over") {
         Step s1;
@@ -1194,7 +1193,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand variable over context without initial value") {
         Step s1;
@@ -1207,7 +1206,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand bool variable over context without initial value") {
         Step s1;
@@ -1220,8 +1219,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<Integer>(ctx.variables["a"]));
-        REQUIRE(ctx.variables["a"] == VariableValue{ Integer{ 4 }}); // Another variant to check variables
+        CAPTURE(std::get<VarInteger>(ctx.variables["a"]));
+        REQUIRE(ctx.variables["a"] == VariableValue{ VarInteger{ 4 }}); // Another variant to check variables
     }
     SECTION("Hand nil variable over context without initial value") {
         Step s1;
@@ -1238,8 +1237,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s2);
         seq.push_back(s3);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<Integer>(ctx.variables["a"]));
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
+        CAPTURE(std::get<VarInteger>(ctx.variables["a"]));
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
     }
     SECTION("Check nil is really non-existing") {
@@ -1266,8 +1265,8 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s3);
         seq.push_back(s4);
         seq.execute(ctx, nullptr);
-        CAPTURE(std::get<Integer>(ctx.variables["a"]));
-        REQUIRE(std::get<Integer>(ctx.variables["a"]) == 1);
+        CAPTURE(std::get<VarInteger>(ctx.variables["a"]));
+        REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 1);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
     }
 }
@@ -1292,7 +1291,7 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
           "change", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = Integer{ 1 };
+    context.variables["a"] = VarInteger{ 1 };
 
     Step step_action1;
     step_action1.set_label("Action");
@@ -1310,13 +1309,13 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
 
     REQUIRE_THROWS(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() != "");
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 1);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 1);
 }
 
 TEST_CASE("execute(): complex sequence with context change", "[Sequence]")
 {
     Context context;
-    context.variables["a"] = Integer{ 1 };
+    context.variables["a"] = VarInteger{ 1 };
 
     Step step_action1;
     step_action1.set_label("Action1");
@@ -1329,7 +1328,7 @@ TEST_CASE("execute(): complex sequence with context change", "[Sequence]")
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     REQUIRE(sequence.get_error_message() == "");
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): if-else sequence", "[Sequence]")
@@ -1383,19 +1382,19 @@ TEST_CASE("execute(): if-else sequence", "[Sequence]")
     SECTION("if-else sequence with if=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-else sequence with if=false")
     {
         Context context;
-        context.variables["a"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 3);
     }
 }
 
@@ -1450,28 +1449,28 @@ TEST_CASE("execute(): if-elseif sequence", "[Sequence]")
     SECTION("if-elseif sequence with if=elseif=false")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
+        context.variables["a"] = VarInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 0);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 0);
     }
 
     SECTION("if-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif sequence with elseif=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 3);
     }
 }
 
@@ -1540,28 +1539,28 @@ TEST_CASE("execute(): if-elseif-else sequence", "[Sequence]")
     SECTION("if-elseif-else sequence with if=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-else sequence with elseif=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-else sequence with else=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 3 };
+        context.variables["a"] = VarInteger{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -1630,37 +1629,37 @@ TEST_CASE("execute(): if-elseif-elseif sequence", "[Sequence]")
     SECTION("if-elseif-elseif sequence with if=elseif=elseif=false")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
+        context.variables["a"] = VarInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 0);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 0);
     }
 
     SECTION("if-elseif-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[1]=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[2]=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 3 };
+        context.variables["a"] = VarInteger{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -1742,37 +1741,37 @@ TEST_CASE("execute(): if-elseif-elseif-else sequence", "[Sequence]")
     SECTION("if-elseif-elseif sequence with if=elseif=elseif=false")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
+        context.variables["a"] = VarInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 5);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 5);
     }
 
     SECTION("if-elseif-elseif sequence with if=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[1]=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 3);
     }
 
     SECTION("if-elseif-elseif sequence with elseif[2]=true")
     {
         Context context;
-        context.variables["a"] = Integer{ 3 };
+        context.variables["a"] = VarInteger{ 3 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -1826,28 +1825,28 @@ TEST_CASE("execute(): if-elseif-else-end sequence with empty blocks", "[Sequence
     SECTION("IF condition true")
     {
         Context context;
-        context.variables["a"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 1 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("First ELSEIF condition true")
     {
         Context context;
-        context.variables["a"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 2 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("Second ELSEIF condition true")
     {
         Context context;
-        context.variables["a"] = Integer{ 3 };
+        context.variables["a"] = VarInteger{ 3 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 
     SECTION("All conditions false, use ELSE branch")
     {
         Context context;
-        context.variables["a"] = Integer{ 4 };
+        context.variables["a"] = VarInteger{ 4 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
     }
 }
@@ -1914,7 +1913,7 @@ TEST_CASE("execute(): faulty if-else-elseif sequence", "[Sequence]")
     sequence.push_back(step_if_end);
 
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     REQUIRE(sequence.get_error_message() == "");
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
@@ -1958,10 +1957,10 @@ TEST_CASE("execute(): while sequence", "[Sequence]")
     SECTION("while sequence with while: a<10")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
+        context.variables["a"] = VarInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 10);
     }
 }
 
@@ -1995,10 +1994,10 @@ TEST_CASE("execute(): empty while sequence", "[Sequence]")
     SECTION("while sequence with while: a<10")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
+        context.variables["a"] = VarInteger{ 0 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 10);
     }
 }
 
@@ -2047,10 +2046,10 @@ TEST_CASE("execute(): try sequence with success", "[Sequence]")
     sequence.push_back(step_try_end);
 
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 1);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 1);
 }
 
 TEST_CASE("execute(): try sequence with fault", "[Sequence]")
@@ -2105,10 +2104,10 @@ TEST_CASE("execute(): try sequence with fault", "[Sequence]")
     sequence.push_back(step_try_end);
 
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex try sequence with nested fault condition",
@@ -2197,10 +2196,10 @@ TEST_CASE("execute(): complex try sequence with nested fault condition",
     sequence.push_back(step_10);
 
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 3);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 3);
 }
 
 TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
@@ -2263,11 +2262,11 @@ TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
     sequence.push_back(step_06);
 
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
     REQUIRE(sequence.get_error_message() != "");
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
@@ -2363,7 +2362,7 @@ TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
 
     Context context;
     REQUIRE_THROWS_AS(sequence.execute(context, nullptr), Error);
-    REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
+    REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
 }
 
 TEST_CASE("execute(): complex sequence", "[Sequence]")
@@ -2624,89 +2623,89 @@ TEST_CASE("execute(): complex sequence", "[Sequence]")
     {
         Context context;
         // a=0, b=0, c=0, d=0/1/2, e=1/2/3, f=0, g=2/1
-        context.variables["a"] = Integer{ 0 };
-        context.variables["b"] = Integer{ 0 };
-        context.variables["c"] = Integer{ 0 };
-        context.variables["d"] = Integer{ 0 };
-        context.variables["e"] = Integer{ 1 };
-        context.variables["f"] = Integer{ 1 };
-        context.variables["g"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 0 };
+        context.variables["b"] = VarInteger{ 0 };
+        context.variables["c"] = VarInteger{ 0 };
+        context.variables["d"] = VarInteger{ 0 };
+        context.variables["e"] = VarInteger{ 1 };
+        context.variables["f"] = VarInteger{ 1 };
+        context.variables["g"] = VarInteger{ 1 };
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
 
         // a=10, b=1, c=1, d=0/2/3, e=1/3/4, f=2, g=1/2
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
-        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["d"]) == 0);
-        REQUIRE(std::get<Integer>(context.variables["e"]) == 1); // not touched
-        REQUIRE(std::get<Integer>(context.variables["f"]) == 1); // not touched
-        REQUIRE(std::get<Integer>(context.variables["g"]) == 1); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<VarInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["d"]) == 0);
+        REQUIRE(std::get<VarInteger>(context.variables["e"]) == 1); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["f"]) == 1); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["g"]) == 1); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 1->3, e: 1->2, f: 1->1, "
             "g: 1->1")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
-        context.variables["b"] = Integer{ 0 };
-        context.variables["c"] = Integer{ 0 };
-        context.variables["d"] = Integer{ 1 };
-        context.variables["e"] = Integer{ 1 };
-        context.variables["f"] = Integer{ 1 };
-        context.variables["g"] = Integer{ 1 };
+        context.variables["a"] = VarInteger{ 0 };
+        context.variables["b"] = VarInteger{ 0 };
+        context.variables["c"] = VarInteger{ 0 };
+        context.variables["d"] = VarInteger{ 1 };
+        context.variables["e"] = VarInteger{ 1 };
+        context.variables["f"] = VarInteger{ 1 };
+        context.variables["g"] = VarInteger{ 1 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
-        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["d"]) == 3);
-        REQUIRE(std::get<Integer>(context.variables["e"]) == 2);
-        REQUIRE(std::get<Integer>(context.variables["f"]) == 1); // not touched
-        REQUIRE(std::get<Integer>(context.variables["g"]) == 1); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<VarInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["d"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["e"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["f"]) == 1); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["g"]) == 1); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 2->3, e: 5->5, f: 2->2, "
             "g: 3->3")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
-        context.variables["b"] = Integer{ 0 };
-        context.variables["c"] = Integer{ 1 };
-        context.variables["d"] = Integer{ 2 };
-        context.variables["e"] = Integer{ 5 };
-        context.variables["f"] = Integer{ 3 };
-        context.variables["g"] = Integer{ 2 };
+        context.variables["a"] = VarInteger{ 0 };
+        context.variables["b"] = VarInteger{ 0 };
+        context.variables["c"] = VarInteger{ 1 };
+        context.variables["d"] = VarInteger{ 2 };
+        context.variables["e"] = VarInteger{ 5 };
+        context.variables["f"] = VarInteger{ 3 };
+        context.variables["g"] = VarInteger{ 2 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
-        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["d"]) == 3);
-        REQUIRE(std::get<Integer>(context.variables["e"]) == 5); // not touched
-        REQUIRE(std::get<Integer>(context.variables["f"]) == 3); // not touched
-        REQUIRE(std::get<Integer>(context.variables["g"]) == 2); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<VarInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["d"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["e"]) == 5); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["f"]) == 3); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["g"]) == 2); // not touched
     }
 
     SECTION("complex sequence: a: 0->10, b: 0->1, c: 0->1, d: 1->3, e: 2->4, f: 3->2, "
             "g: 4->2")
     {
         Context context;
-        context.variables["a"] = Integer{ 0 };
-        context.variables["b"] = Integer{ 0 };
-        context.variables["c"] = Integer{ 1 };
-        context.variables["d"] = Integer{ 1 };
-        context.variables["e"] = Integer{ 2 };
-        context.variables["f"] = Integer{ 3 };
-        context.variables["g"] = Integer{ 4 };
+        context.variables["a"] = VarInteger{ 0 };
+        context.variables["b"] = VarInteger{ 0 };
+        context.variables["c"] = VarInteger{ 1 };
+        context.variables["d"] = VarInteger{ 1 };
+        context.variables["e"] = VarInteger{ 2 };
+        context.variables["f"] = VarInteger{ 3 };
+        context.variables["g"] = VarInteger{ 4 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 10);
-        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["c"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["d"]) == 3);
-        REQUIRE(std::get<Integer>(context.variables["e"]) == 3);
-        REQUIRE(std::get<Integer>(context.variables["f"]) == 3); // not touched
-        REQUIRE(std::get<Integer>(context.variables["g"]) == 4); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 10);
+        REQUIRE(std::get<VarInteger>(context.variables["b"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["c"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["d"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["e"]) == 3);
+        REQUIRE(std::get<VarInteger>(context.variables["f"]) == 3); // not touched
+        REQUIRE(std::get<VarInteger>(context.variables["g"]) == 4); // not touched
     }
 }
 
@@ -2871,7 +2870,7 @@ TEST_CASE("execute_sequence(): Messages", "[execute_sequence]")
     auto& queue = comm.queue_;
 
     Context context;
-    context.variables["a"] = Integer{ 0 };
+    context.variables["a"] = VarInteger{ 0 };
 
     Step step1{ Step::type_action };
     step1.set_used_context_variable_names(VariableNames{ "a" });
@@ -2999,11 +2998,11 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     SECTION("All steps enabled")
     {
         Context context;
-        context.variables["a"] = Integer{ 5 };
+        context.variables["a"] = VarInteger{ 5 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 2);
-        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
+        REQUIRE(std::get<VarInteger>(context.variables["b"]) == 1);
     }
 
     sequence.modify(sequence.begin() + 1, [](Step& s) {
@@ -3014,11 +3013,11 @@ TEST_CASE("execute(): if-elseif-else sequence with disable", "[Sequence]")
     SECTION("Second step disabled")
     {
         Context context;
-        context.variables["a"] = Integer{ 5 };
+        context.variables["a"] = VarInteger{ 5 };
 
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 1);
-        REQUIRE(std::get<Integer>(context.variables["b"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 1);
+        REQUIRE(std::get<VarInteger>(context.variables["b"]) == 1);
     }
 }
 
@@ -3046,7 +3045,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 6);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 6);
     }
 
     sequence.modify(sequence.begin() + 1, [](Step& s) {
@@ -3057,7 +3056,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 5);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 5);
     }
 
     sequence.modify(sequence.begin() + 2, [](Step& s) {
@@ -3068,7 +3067,7 @@ TEST_CASE("execute(): sequence with multiple disabled", "[Sequence]")
     {
         Context context;
         REQUIRE_NOTHROW(sequence.execute(context, nullptr));
-        REQUIRE(std::get<Integer>(context.variables["a"]) == 4);
+        REQUIRE(std::get<VarInteger>(context.variables["a"]) == 4);
     }
 }
 
@@ -3146,7 +3145,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = Integer{ 5 };
+        context.variables["a"] = VarInteger{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == true);
@@ -3173,7 +3172,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = Integer{ 5 };
+        context.variables["a"] = VarInteger{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == false);
@@ -3200,7 +3199,7 @@ TEST_CASE("execute(): disable 'invariant' (direct)", "[Sequence]")
         sequence.push_back(step_post); // b = 1
 
         Context context;
-        context.variables["a"] = Integer{ 5 };
+        context.variables["a"] = VarInteger{ 5 };
 
         REQUIRE(sequence[0].is_disabled() == false);
         REQUIRE(sequence[1].is_disabled() == false);
@@ -3284,7 +3283,7 @@ TEST_CASE("execute(): disable 'invariant' (afterwards)", "[Sequence]")
     sequence.push_back(step_post); // b = 1
 
     Context context;
-    context.variables["a"] = Integer{ 5 };
+    context.variables["a"] = VarInteger{ 5 };
 
     SECTION("Second step disabled")
     {
@@ -3544,7 +3543,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
 
     step_while_end.set_label("end loop");
 
-    ctx.variables["a"] = Integer{ 0 };
+    ctx.variables["a"] = VarInteger{ 0 };
 
     seq.push_back(step_while);
     seq.push_back(step_increment);
@@ -3558,7 +3557,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
     for (const auto& step : seq)
         REQUIRE(step.is_running() == false);
 
-    REQUIRE(std::get<Integer>(ctx.variables["a"]) == 4);
+    REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
     REQUIRE(not queue.empty());
     REQUIRE(queue.size() == 26);
     auto msg = queue.back();

--- a/tests/test_lua_details.cc
+++ b/tests/test_lua_details.cc
@@ -40,7 +40,7 @@ TEST_CASE("get_ms_since_epoch()", "[lua_details]")
     REQUIRE(get_ms_since_epoch(now, 100ms)
             == round<milliseconds>((now + 100ms).time_since_epoch()).count());
 
-    if constexpr (milliseconds::max().count() >= std::numeric_limits<long long>::max())
+    if constexpr (milliseconds::max().count() >= std::numeric_limits<LuaInteger>::max())
     {
         REQUIRE(get_ms_since_epoch(now, milliseconds::max())
                 == std::numeric_limits<LuaInteger>::max());

--- a/tests/test_lua_details.cc
+++ b/tests/test_lua_details.cc
@@ -43,6 +43,6 @@ TEST_CASE("get_ms_since_epoch()", "[lua_details]")
     if constexpr (milliseconds::max().count() >= std::numeric_limits<long long>::max())
     {
         REQUIRE(get_ms_since_epoch(now, milliseconds::max())
-                == std::numeric_limits<long long>::max());
+                == std::numeric_limits<LuaInteger>::max());
     }
 }


### PR DESCRIPTION
**[why]**
When we want to interface with the Lua data types that are held in the Lua state we need to use specific C++ types. These types (for example `long long` have been used directly and often it is not so clear why some type is used.

**[how]**
Use alias types that clearly communicate to the reader of the case that some value for interfacing with Lua is to be used/created/stored.

When using these also consistently to create assignments the whole problem of variant's char*-to-bool quirk goes away. We could even introduce not alias types but real types instead to be even more type save.

**[note]**
Also unify the test code a bit.

Also change how the values in the Context.variables are compared (sometimes). We compare the values, not the variants.

Also add missing LuaBool export from Script test.

Also add missing funtion export from Script test.

Fixes: #47