### PR TITLE
Cleanup: Unify exception classes

### DIFF
--- a/include/taskolib/Step.h
+++ b/include/taskolib/Step.h
@@ -102,7 +102,7 @@ public:
      *         function returns the return value of the script. For other step types
      *         (ACTION etc.), it returns false.
      *
-     * \exception Error or ErrorAtIndex is thrown if the script cannot be started, if
+     * \exception Error is thrown if the script cannot be started, if
      *            there is a Lua error during execution, if the script has an
      *            inappropriate return value for the step type (see above), if a timeout
      *            is encountered, or if termination has been requested via the
@@ -136,7 +136,7 @@ public:
      *         function returns the return value of the script. For other step types
      *         (ACTION etc.), it returns false.
      *
-     * \exception Error or ErrorAtIndex is thrown if the script cannot be started, if
+     * \exception Error is thrown if the script cannot be started, if
      *            there is a Lua error during execution, if the script has an
      *            inappropriate return value for the step type (see above), if a timeout
      *            is encountered, or if termination has been requested explicitly by the

--- a/include/taskolib/exceptions.h
+++ b/include/taskolib/exceptions.h
@@ -2,7 +2,7 @@
  * \file   exceptions.h
  * \author Lars Froehlich
  * \date   Created on July 4, 2017
- * \brief  Definitions of the Error and ErrorAtIndex exception classes.
+ * \brief  Definition of the Error exception class.
  *
  * \copyright Copyright 2017-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -34,10 +34,11 @@
 namespace task {
 
 /**
- * A generic exception class carrying a message string.
+ * An exception class carrying an error message and, optionally, the index of the step in
+ * which the error occurred.
  *
- * The Error class is used as the standard exception by many functions throughout
- * Taskolib. It can be used directly or inherited from.
+ * Error is used as the standard exception class by many functions throughout Taskolib.
+ * It can be used directly or inherited from.
  *
  * \code
  * try
@@ -47,6 +48,19 @@ namespace task {
  * catch (const task::Error& e)
  * {
  *     std::cerr << e.what() << "\n";
+ * }
+ *
+ * try
+ * {
+ *     throw task::Error("An error has occurred", 42);
+ * }
+ * catch (const task::Error& e)
+ * {
+ *     std::cerr << e.what();
+ *     auto maybe_step_index = e.get_index();
+ *     if (maybe_step_index)
+ *         std::cerr << ": step index " << *maybe_step_index;
+ *     std::cerr << "\n";
  * }
  * \endcode
  *
@@ -58,47 +72,21 @@ namespace task {
 class Error : public std::runtime_error
 {
 public:
-    using std::runtime_error::runtime_error;
-};
-
-/**
- * An exception class storing the index of the step in which an error occurred, in
- * addition to the error message.
- *
- * \code
- * try
- * {
- *     throw task::ErrorAtIndex("An error has occurred", 42);
- * }
- * catch (const task::ErrorAtIndex& e)
- * {
- *     std::cerr << e.what() << " in step " << e.get_index() << "\n";
- * }
- * \endcode
- *
- * \note
- * task::ErrorAtIndex inherits from std::runtime_error. It can therefore be caught by
- * `catch (const std::exception&)`, `catch (const std::runtime_error&)`,
- * `catch (const task::Error&)`, and `catch (const task::ErrorAtIndex&)`.
- */
-class ErrorAtIndex : public Error
-{
-public:
-    ErrorAtIndex(const std::string& msg, StepIndex index)
-        : Error(msg)
-        , index_(index)
+    explicit Error(const std::string& msg, OptionalStepIndex opt_step_index = gul14::nullopt)
+        : std::runtime_error(msg)
+        , index_{ opt_step_index }
     {}
 
-    ErrorAtIndex(const char* msg, StepIndex index)
-        : Error(msg)
-        , index_(index)
+    explicit Error(const char* msg, OptionalStepIndex opt_step_index = gul14::nullopt)
+        : std::runtime_error(msg)
+        , index_{ opt_step_index }
     {}
 
     /// Return the associated step index.
-    StepIndex get_index() const noexcept { return index_; }
+    OptionalStepIndex get_index() const { return index_; }
 
 private:
-    StepIndex index_ = 0;
+    OptionalStepIndex index_;
 };
 
 } // namespace task

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -303,7 +303,7 @@ void Sequence::execute(Context& context, CommChannel* comm)
         check_syntax();
         execute_sequence_impl(steps_.begin(), steps_.end(), context, comm);
     }
-    catch (const ErrorAtIndex& e)
+    catch (const Error& e)
     {
         exception_thrown = true;
         exception_message = e.what();

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -186,7 +186,7 @@ bool Step::execute(Context& context, CommChannel* comm, StepIndex index)
         auto [msg, _] = remove_abort_markers(e.what());
         send_message(comm, Message::Type::step_stopped_with_error, msg, Clock::now(),
                      index);
-        throw ErrorAtIndex(e.what(), index);
+        throw Error(e.what(), index);
     }
 }
 

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -280,7 +280,7 @@ TEST_CASE("execute(): Return value handling in scripts requiring a bool result",
         Step step{ type };
 
         SECTION("Empty step throws") {
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return true' returns true") {
@@ -295,32 +295,32 @@ TEST_CASE("execute(): Return value handling in scripts requiring a bool result",
 
         SECTION("'return nil' throws") {
             step.set_script("return nil");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return 42' throws") {
             step.set_script("return 42");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return 0' throws") {
             step.set_script("return 0");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return 0.1' throws") {
             step.set_script("return 0.1");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return 0.0' throws") {
             step.set_script("return 0.0");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("\"return 'false'\" throws") {
             step.set_script("return 'false'");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
     }
 }
@@ -348,27 +348,27 @@ TEST_CASE("execute(): Return value handling in scripts requiring no result", "[S
 
         SECTION("'return true' throws") {
             step.set_script("return true");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return false' throws") {
             step.set_script("return false");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return 0' throws") {
             step.set_script("return 0");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("'return 0.0' throws") {
             step.set_script("return 0.0");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
 
         SECTION("\"return 'black cow'\" throws") {
             step.set_script("return 'black cow'");
-            REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+            REQUIRE_THROWS_AS(step.execute(context), Error);
         }
     }
 }
@@ -428,8 +428,8 @@ TEST_CASE("execute(): C++ exceptions", "[Step]")
         step.set_script("throw_logic_error(); a = 42");
 
         // Like a genuine Lua exception, a C++ exception must be reported as a
-        // task::ErrorAtIndex.
-        REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+        // task::Error.
+        REQUIRE_THROWS_AS(step.execute(context), Error);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == 0);
     }
 
@@ -437,7 +437,7 @@ TEST_CASE("execute(): C++ exceptions", "[Step]")
     {
         step.set_script("throw_weird_exception(); a = 42");
 
-        REQUIRE_THROWS_AS(step.execute(context), ErrorAtIndex);
+        REQUIRE_THROWS_AS(step.execute(context), Error);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == 0);
     }
 

--- a/tests/test_exceptions.cc
+++ b/tests/test_exceptions.cc
@@ -2,7 +2,7 @@
  * \file   test_exceptions.cc
  * \author Lars Froehlich
  * \date   Created on December 10, 2021
- * \brief  Test suite for the Error and ErrorAtIndex exception classes.
+ * \brief  Test suite for the Error exception class.
  *
  * \copyright Copyright 2021-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -31,48 +31,38 @@ using namespace task;
 
 TEST_CASE("Error: Constructor", "[exceptions]")
 {
-    Error e("Test");
+    SECTION("Single argument")
+    {
+        Error e("Test");
+        REQUIRE(e.what() == "Test"s);
+        REQUIRE(e.get_index() == gul14::nullopt);
+    }
+
+    SECTION("Two arguments")
+    {
+        Error e("tesT", 42);
+        REQUIRE(e.what() == "tesT"s);
+        REQUIRE(e.get_index().has_value());
+        REQUIRE(e.get_index().value() == 42);
+    }
 }
 
 TEST_CASE("Error: Copy constructor", "[exceptions]")
 {
-    Error e("Test");
+    Error e("Test", 42);
     Error e2(e);
-
-    REQUIRE(e.what() == std::string(e2.what()));
-}
-
-TEST_CASE("Error: Copy assignment", "[exceptions]")
-{
-    Error e("Test");
-    Error e2("Test2");
-
-    e2 = e;
-
-    REQUIRE(e2.what() == "Test"s);
-}
-
-TEST_CASE("ErrorAtIndex: Constructor", "[exceptions]")
-{
-    ErrorAtIndex e("Test", 0);
-}
-
-TEST_CASE("ErrorAtIndex: Copy constructor", "[exceptions]")
-{
-    ErrorAtIndex e("Test", 42);
-    ErrorAtIndex e2(e);
 
     REQUIRE(e.what() == std::string(e2.what()));
     REQUIRE(e.get_index() == e2.get_index());
 }
 
-TEST_CASE("ErrorAtIndex: Copy assignment", "[exceptions]")
+TEST_CASE("Error: Copy assignment", "[exceptions]")
 {
-    ErrorAtIndex e("Test", 1);
-    ErrorAtIndex e2("Test2", 2);
+    const Error e("Test", 1);
+    Error e2("Test2", 2);
 
     e2 = e;
 
     REQUIRE(e2.what() == "Test"s);
-    REQUIRE(e2.get_index() == 1);
+    REQUIRE(e2.get_index() == e.get_index());
 }


### PR DESCRIPTION
This came out of a discussion on #52: Why do we maintain two separate exception classes, `Error` and `ErrorAtIndex`, if we could just put an `OptionalStepIndex` directly into the `Error` class? This is what this PR does.