### PR TITLE
Executor: Fix forceful cancellation

### DIFF
--- a/include/taskolib/Executor.h
+++ b/include/taskolib/Executor.h
@@ -121,8 +121,20 @@ public:
      * If a sequence is running in a separate thread, this call sends a termination
      * request and waits for the thread to shut down. If no sequence is currently running,
      * the call has no effect.
+     * An associated Sequence will not be updated and all messages are lost.
+     * Usually you should call \ref cancel(Sequence& sequence).
      */
     void cancel();
+
+    /**
+     * Terminate a running sequence.
+     *
+     * If a sequence is running in a separate thread, this call sends a termination
+     * request and waits for the thread to shut down. If no sequence is currently running,
+     * the call has no effect.
+     * The associated Sequence will be updated with all pending messages.
+     */
+    void cancel(Sequence& sequence);
 
     /**
      * Start a copy of the given sequence in a separate thread.

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -388,6 +388,8 @@ Sequence::execute_sequence_impl(Iterator step_begin, Iterator step_end, Context&
 {
     Iterator step = step_begin;
 
+    if (comm and comm->immediate_termination_requested_)
+        throw Error{ gul14::cat(abort_marker, "Stop on user request") };
     while (step < step_end)
     {
         if (step->is_disabled())

--- a/tests/test_LockedQueue.cc
+++ b/tests/test_LockedQueue.cc
@@ -25,6 +25,7 @@
 #include <thread>
 #include <type_traits>
 #include <gul14/catch.h>
+#include <gul14/time_util.h>
 #include "taskolib/exceptions.h"
 #include "taskolib/Message.h"
 #include "taskolib/LockedQueue.h"
@@ -130,6 +131,7 @@ TEST_CASE("LockedQueue: push() & pop() across threads", "[LockedQueue]")
                 queue.push(MyMessage(i));
         });
 
+    gul14::sleep(0.005);
     // Pull all 100 messages out of the queue from the main thread
     for (int i = 1; i <= 100; ++i)
     {


### PR DESCRIPTION
**[why]**
When a Sequence runs asynchronously and produces so much messages that the message queue gets clogged up we can not force-stop the Sequence or destruct the Executor anymore.

**A)**
The reason is that we can not call `cancel()` on the Executor. The executing thread is already waiting for a slot in the queue. But when we call `cancel()` the Executor just waits for the thread to become ready (joinable). That will never happen, because it waits on the queue, ...

**B)**
When we want to cancel the Sequence this is detected too late (or never) under certain circumstances, because it is only checked in the running Lua VM debug hook.

**[how]**
**A)**
Distinguish between 'last resort' `cancel()` and 'orderly' `cancel()`. Introduce a new function for the later, that takes a Sequence reference and first empties the message queue into that Sequence, and thus allows the executing thread to drop all the pending messages until it notices that it shall stop, and then stop and join.

The last-resort `cancel()` now just drops any (most) pending messages to enable the executing thread to finish. That is needed for situations where we do not know which Sequence is run (i.e. in the destructor). It might be useful for users, otherwise it could be private.

**B)**
Check if the Sequence shall terminate before executing the next pending Step.

Fixes: #54