### PR TITLE
Sequence: Fix user-termination on many action Steps

### DIFF
--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -388,8 +388,6 @@ Sequence::execute_sequence_impl(Iterator step_begin, Iterator step_end, Context&
 {
     Iterator step = step_begin;
 
-    if (comm and comm->immediate_termination_requested_)
-        throw Error{ gul14::cat(abort_marker, "Stop on user request") };
     while (step < step_end)
     {
         if (step->is_disabled())
@@ -397,6 +395,8 @@ Sequence::execute_sequence_impl(Iterator step_begin, Iterator step_end, Context&
             ++step;
             continue;
         }
+        if (comm and comm->immediate_termination_requested_)
+            throw Error{ gul14::cat(abort_marker, "Stop on user request") , step - steps_.begin() };
 
         switch (step->get_type())
         {


### PR DESCRIPTION
[why]
When you have a sequence of lots of action Steps the termination flag will not be checked in between the Steps.

[how]
Check the flag each time before a Step is called.

Reported-by: Lars Froehlich <lars.froehlich@desy.de>
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>