### PR TITLE
SerDes: downsizing operators to serialize/deserialize sequence and steps

### DIFF
--- a/include/taskolib/deserialize_sequence.h
+++ b/include/taskolib/deserialize_sequence.h
@@ -44,13 +44,13 @@ namespace task {
 std::istream& operator>>(std::istream& stream, Step& step);
 
 /**
- * Extracts and creates from \a path a Step and returns it. The file path must be a Lua
+ * Extracts and creates from \a folder a Step and returns it. The filename must be a Lua
  * script and should have the extension 'lua'.
  *
- * It will throw an Error exception if an I/O error occurs on the external file path or
- * the file does not exist.
+ * It will throw an Error exception if an I/O error occurs on the external filename object
+ * or the file does not exist.
  *
- * To deserialize a Step it must consist with following minimum properties:
+ * To load a Step it must consist of the following minimum properties:
  * \code
  * -- type: action \a or if \a or ...
  * -- label: < \a label \a description >
@@ -63,6 +63,12 @@ std::istream& operator>>(std::istream& stream, Step& step);
  * -- time of last execution: %Y-%m-%d %H:%M:%S
  * -- timeout: [infinity|< \a timeout \a in \a milliseconds >]
  * \endcode
+ *
+ * If one of the optional parameters is not set the following is provided as default:
+ * - context variable names is an empty list
+ * - time of last modification is set to a time stamp when loaded
+ * - time of last execution is set to January 1st 1970
+ * - timeout is set to 0s
  *
  * Here is one example of a stored Step \a step_001_while.lua :
  * \code
@@ -84,29 +90,59 @@ std::istream& operator>>(std::istream& stream, Step& step);
  * the time on loading the step.
  * \note the collection of context variable names can also be an empty list, ie. \c [] .
  *
- * \param path  the path to a file from which the step should be loaded
+ * \param folder from which the Step should be loaded.
+ * \param folder from which the Step should be loaded.
  * \returns the deserialized Step object.
  */
-Step deserialize_step(const std::filesystem::path& path);
+Step load_step(const std::filesystem::path& folder);
 
 /**
- * Deserialize parameters of Sequence from the input stream.
+ * Load a step setup script into the Sequence.
  *
- * No checking of any stream failure is done and should be performed by the caller.
- *
- * \param stream input stream
- * \param step Sequence to be deserialized.
- * \return passed input stream
+ * \param folder of the Sequence.
+ * \param sequence to store the loaded step setup script.
+ * \see Sequence for step setup script.
  */
-std::istream& operator>>(std::istream& stream, Sequence& seq);
+void load_step_setup_script(const std::filesystem::path& folder, Sequence& sequence);
 
 /**
- * Deserialize Sequence from file path.
+ * Loads a Sequence with all of the stored Step's from the folder.
  *
- * \param path  a directory from which the sequence should be loaded
+ * \param folder from which the Sequence should be loaded.
+ * \returns the loaded Sequence object.
+ */
+Sequence load_sequence(const std::filesystem::path& folder);
+
+/**
+ * For description see load_step().
+ *
+ * \param folder from which the Step should be loaded.
+ * \returns the deserialized Step object.
+ * \deprecated Use load_step() instead.
+ */
+[[deprecated("Use load_step() instead.")]]
+Step deserialize_step(const std::filesystem::path& folder);
+
+/**
+ * Load a step setup script into the Sequence.
+ *
+ * \param folder of the Sequence.
+ * \param sequence to store the loaded step setup script.
+ * \see Sequence for step setup script.
+ * \deprecated Use load_step_setup_script() instead.
+ */
+[[deprecated("Use load_step_setup_script() instead.")]]
+void deserialize_step_setup_script(const std::filesystem::path& folder, Sequence& sequence);
+
+/**
+ * Deserialize Sequence with all of the stored Step's from folder.
+ *
+ * \param folder from which the Sequence should be loaded.
  * \returns the deserialized Sequence object.
+ * \deprecated Use load_sequence() instead.
  */
-Sequence deserialize_sequence(const std::filesystem::path& path);
+[[deprecated("Use load_sequence() instead.")]]
+Sequence deserialize_sequence(const std::filesystem::path& folder);
 
 } // namespace task
 

--- a/include/taskolib/deserialize_sequence.h
+++ b/include/taskolib/deserialize_sequence.h
@@ -44,19 +44,22 @@ namespace task {
 std::istream& operator>>(std::istream& stream, Step& step);
 
 /**
- * Extracts and creates from \a folder a Step and returns it. The filename must be a Lua
- * script and should have the extension 'lua'.
+ * Read a Step from a file and return it.
+ *
+ * \param lua_file  The filename from which to read the step. The file must be a Lua
+ *                  script and should have the extension 'lua'.
  *
  * It will throw an Error exception if an I/O error occurs on the external filename object
  * or the file does not exist.
  *
- * To load a Step it must consist of the following minimum properties:
+ * Lua comments in the header of the file are used to read metadata. To load a Step, it
+ * must have at least the following properties:
  * \code
  * -- type: action \a or if \a or ...
  * -- label: < \a label \a description >
  * \endcode
  *
- * Optional are the following properties:
+ * The following properties are optional:
  * \code
  * -- use context variable names: [ \a variable1, ... ]
  * -- time of last modification: %Y-%m-%d %H:%M:%S
@@ -83,18 +86,14 @@ std::istream& operator>>(std::istream& stream, Step& step);
  *
  * The label is explicitly escaped on storing and unescaped on loading.
  *
- * \note \c '--' is a Lua comment and interpreted with special keywords to fill the Step
- * properties.
  * \note for time interpretation see <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a>
  * \note if <tt>>time of last modification</tt> is not provided in the file it is set to
  * the time on loading the step.
  * \note the collection of context variable names can also be an empty list, ie. \c [] .
  *
- * \param folder from which the Step should be loaded.
- * \param folder from which the Step should be loaded.
  * \returns the deserialized Step object.
  */
-Step load_step(const std::filesystem::path& folder);
+Step load_step(const std::filesystem::path& lua_file);
 
 /**
  * Load a step setup script into the Sequence.
@@ -112,37 +111,6 @@ void load_step_setup_script(const std::filesystem::path& folder, Sequence& seque
  * \returns the loaded Sequence object.
  */
 Sequence load_sequence(const std::filesystem::path& folder);
-
-/**
- * For description see load_step().
- *
- * \param folder from which the Step should be loaded.
- * \returns the deserialized Step object.
- * \deprecated Use load_step() instead.
- */
-[[deprecated("Use load_step() instead.")]]
-Step deserialize_step(const std::filesystem::path& folder);
-
-/**
- * Load a step setup script into the Sequence.
- *
- * \param folder of the Sequence.
- * \param sequence to store the loaded step setup script.
- * \see Sequence for step setup script.
- * \deprecated Use load_step_setup_script() instead.
- */
-[[deprecated("Use load_step_setup_script() instead.")]]
-void deserialize_step_setup_script(const std::filesystem::path& folder, Sequence& sequence);
-
-/**
- * Deserialize Sequence with all of the stored Step's from folder.
- *
- * \param folder from which the Sequence should be loaded.
- * \returns the deserialized Sequence object.
- * \deprecated Use load_sequence() instead.
- */
-[[deprecated("Use load_sequence() instead.")]]
-Sequence deserialize_sequence(const std::filesystem::path& folder);
 
 } // namespace task
 

--- a/include/taskolib/serialize_sequence.h
+++ b/include/taskolib/serialize_sequence.h
@@ -4,7 +4,7 @@
  * \date   Created on May 6, 2022
  * \brief  Serialize Sequence and Steps on storage hardware.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -44,8 +44,10 @@ namespace task {
 std::ostream& operator<<(std::ostream& stream, const Step& step);
 
 /**
- * Store Step to the file system. It pushes the following Step properties to the created
- * file stream:
+ * Store a Step in a file.
+ *
+ * This function saves the script of this step in a Lua file. Metadata like the step type
+ * or the label are stored as comments in the header of the file:
  *
  * \code
  * -- type: {action, if, elseif, else, while, try, catch, end}
@@ -75,10 +77,10 @@ std::ostream& operator<<(std::ostream& stream, const Step& step);
  *
  * The label is explicitly escaped on storing and unescaped on loading.
  *
- * \param folder for the Step
- * \param step step to serialize
+ * \param lua_file  filename under which the step should be stored
+ * \param step  the Step object that should be serialized
  */
-void store_step(const std::filesystem::path& folder, const Step& step);
+void store_step(const std::filesystem::path& lua_file, const Step& step);
 
 /**
  * Serialize parameters of Sequence to the output stream.
@@ -92,32 +94,27 @@ void store_step(const std::filesystem::path& folder, const Step& step);
 std::ostream& operator<<(std::ostream& stream, const Sequence& sequence);
 
 /**
- * Stores Sequence with all of its Step 's as files.
+ * Stores the Sequence in a folder containing all steps as individual files.
  *
  * After storing you will find the following structure:
  *
  * - the sequence label is extracted to a folder name, where underneath all steps are
- *  serialized. If the label has one of the following characters they are escaped to
- *  hexadecimal format: /\\:?*"'<>|$&. Moreover all control characters (<= 32) are
- *  converted to space character (' ').
+ *   serialized. If the label has one of the following characters they are escaped to
+ *   hexadecimal format: /\\:?*"'<>|$&. Moreover all control characters (<= 32) are
+ *   converted to space character (' ').
  *
- * - underneath the sequence folder you will find the Step 's serialized in files. To
- *  differ the Step they are enumerated. Each filename starts with `step` followed by a
- *  consecutive step enumeration number followed by type. Since you can directly evaluate
- *  the step as a Lua script it has the extension `'.lua'`. The step numbering is filled
- *  with '0' to allow alphanumerical sorting.
+ * - underneath the sequence folder you will find the steps serialized in files. Each
+ *   filename starts with `step` followed by a consecutive step enumeration number
+ *   followed by the type of the step and the extension `'.lua'`. The step number is
+ *   filled with zeros to allow alphanumerical sorting.
  *
  *  Here is one example for the first step that has type `action`: `step_001_action.lua`
  *
  *  \note Remember that the libary only uses three digit for numbering. There is no
  *  guarantee for serializing more then 1000 Step 's in alphabetical order.
  *
- * - important Step parameters are exported to the beginning of the file as Lua
- *  comments. See ::store_step(const std::filesystem::path&, const Step&) for more
- *  information.
- *
- * \param folder to store Sequence
- * \param sequence to be serialized
+ * \param folder  in which to store the Sequence
+ * \param sequence  the Sequence that should be serialized
  */
 void store_sequence(const std::filesystem::path& folder, const Sequence& sequence);
 

--- a/include/taskolib/serialize_sequence.h
+++ b/include/taskolib/serialize_sequence.h
@@ -121,26 +121,6 @@ std::ostream& operator<<(std::ostream& stream, const Sequence& sequence);
  */
 void store_sequence(const std::filesystem::path& folder, const Sequence& sequence);
 
-/**
- * For a description see store_step().
- *
- * \param folder for the Step
- * \param step step to serialize
- * \deprecated Use store_step() instead.
- */
-[[deprecated("Use store_step() instead.")]]
-void serialize_step(const std::filesystem::path& folder, const Step& step);
-
-/**
- * For a description \see store_sequence().
- *
- * \param folder to store Sequence
- * \param sequence to be serialized
- * \deprecated Use store_sequence(const std::filesystem::path&, const Sequence&) instead.
- */
-[[deprecated("Use store_sequence() instead.")]]
-void serialize_sequence(const std::filesystem::path& folder, const Sequence& sequence);
-
 } // namespace task
 
 #endif

--- a/include/taskolib/serialize_sequence.h
+++ b/include/taskolib/serialize_sequence.h
@@ -37,15 +37,15 @@ namespace task {
  *
  * No checking of any stream failure is done and should be performed by the caller.
  *
- * @param stream to serialize the Step
- * @param step to serialize
- * @return passed output stream
+ * \param stream to serialize the Step
+ * \param step to serialize
+ * \return passed output stream
  */
 std::ostream& operator<<(std::ostream& stream, const Step& step);
 
 /**
- * Serialize Step to the file system. It pushes the Step properties to the
- * stream:
+ * Store Step to the file system. It pushes the following Step properties to the created
+ * file stream:
  *
  * \code
  * -- type: {action, if, elseif, else, while, try, catch, end}
@@ -75,26 +75,26 @@ std::ostream& operator<<(std::ostream& stream, const Step& step);
  *
  * The label is explicitly escaped on storing and unescaped on loading.
  *
- * @param step step to serialize
- * @param path for the Step
+ * \param folder for the Step
+ * \param step step to serialize
  */
-void serialize_step(const std::filesystem::path& path, const Step& step);
+void store_step(const std::filesystem::path& folder, const Step& step);
 
 /**
  * Serialize parameters of Sequence to the output stream.
  *
  * No checking of any stream failure is done and should be performed by the caller.
  *
- * @param stream to serialize the Step
- * @param sequence to serialize
- * @return passed output stream
+ * \param stream to serialize the Step
+ * \param sequence to serialize
+ * \return passed output stream
  */
 std::ostream& operator<<(std::ostream& stream, const Sequence& sequence);
 
 /**
- * Serialize Sequence with all of its Step 's as files.
+ * Stores Sequence with all of its Step 's as files.
  *
- * After serializing you will find the following structure:
+ * After storing you will find the following structure:
  *
  * - the sequence label is extracted to a folder name, where underneath all steps are
  *  serialized. If the label has one of the following characters they are escaped to
@@ -113,13 +113,33 @@ std::ostream& operator<<(std::ostream& stream, const Sequence& sequence);
  *  guarantee for serializing more then 1000 Step 's in alphabetical order.
  *
  * - important Step parameters are exported to the beginning of the file as Lua
- *  comments. See ::serialize_step(const std::filesystem::path&, const Step&) for more
+ *  comments. See ::store_step(const std::filesystem::path&, const Step&) for more
  *  information.
  *
- * @param path to store Sequence
- * @param sequence to be serialized
+ * \param folder to store Sequence
+ * \param sequence to be serialized
  */
-void serialize_sequence(const std::filesystem::path& path, const Sequence& sequence);
+void store_sequence(const std::filesystem::path& folder, const Sequence& sequence);
+
+/**
+ * For a description see store_step().
+ *
+ * \param folder for the Step
+ * \param step step to serialize
+ * \deprecated Use store_step() instead.
+ */
+[[deprecated("Use store_step() instead.")]]
+void serialize_step(const std::filesystem::path& folder, const Step& step);
+
+/**
+ * For a description \see store_sequence().
+ *
+ * \param folder to store Sequence
+ * \param sequence to be serialized
+ * \deprecated Use store_sequence(const std::filesystem::path&, const Sequence&) instead.
+ */
+[[deprecated("Use store_sequence() instead.")]]
+void serialize_sequence(const std::filesystem::path& folder, const Sequence& sequence);
 
 } // namespace task
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -49,7 +49,7 @@ Sequence SequenceManager::load_sequence(std::filesystem::path sequence_path) con
     else if (not std::filesystem::is_directory(sequence))
         throw Error(gul14::cat("File path to sequence is not a directory: ",
             sequence.string()));
-    return deserialize_sequence(sequence);
+    return task::load_sequence(sequence);
 }
 
 } // namespace task

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -326,13 +326,13 @@ std::istream& operator>>(std::istream& stream, Step& step)
     return stream;
 }
 
-Step load_step(const std::filesystem::path& folder)
+Step load_step(const std::filesystem::path& lua_file)
 {
     Step step{};
-    std::ifstream stream(folder);
+    std::ifstream stream(lua_file);
 
     if (not stream.is_open())
-        throw Error(gul14::cat("I/O error: unable to open file '", folder.string(), "'"));
+        throw Error(gul14::cat("I/O error: unable to open file '", lua_file.string(), "'"));
 
     stream >> step; // RAII closes the stream (let the destructor do the job)
 
@@ -385,21 +385,6 @@ Sequence load_sequence(const std::filesystem::path& folder)
     }
 
     return seq;
-}
-
-Step deserialize_step(const std::filesystem::path& folder)
-{
-    return load_step(folder);
-}
-
-void deserialize_step_setup_script(const std::filesystem::path& folder, Sequence& sequence)
-{
-    return load_step_setup_script(folder, sequence);
-}
-
-Sequence deserialize_sequence(const std::filesystem::path& folder)
-{
-    return load_sequence(folder);
 }
 
 } // namespace task

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -4,7 +4,7 @@
  * \date   Created on May 24, 2022
  * \brief  Deserialize Sequence and Steps from storage hardware.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,16 +22,18 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <chrono>
-#include <fstream>
-#include <vector>
-#include <string>
-#include <sstream>
-#include <cctype>
-#include <ctime>
-#include <set>
 #include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <ctime>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <gul14/gul.h>
+
 #include "internals.h"
 #include "taskolib/hash_string.h"
 #include "taskolib/deserialize_sequence.h"
@@ -344,7 +346,7 @@ void load_step_setup_script(const std::filesystem::path& folder, Sequence& seque
     if (not std::filesystem::exists(folder))
         throw Error(gul14::cat("Folder does not exist: '", folder.string(), '\''));
 
-    std::string step_setup_script = ""; // set an empty step setup script
+    std::string step_setup_script;
 
     auto stream = std::ifstream(folder / sequence_lua_filename);
     if (stream.good())

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -382,7 +382,7 @@ Sequence load_sequence(const std::filesystem::path& folder)
             [](const auto& lhs, const auto& rhs) -> bool
             { return lhs.filename() < rhs.filename(); });
 
-        for(auto entry: steps)
+        for (const auto& entry : steps)
             seq.push_back(load_step(entry));
     }
 

--- a/src/serialize_sequence.cc
+++ b/src/serialize_sequence.cc
@@ -146,14 +146,14 @@ std::ostream& operator<<(std::ostream& stream, const Sequence& sequence)
     return stream;
 }
 
-void serialize_sequence_impl(const std::filesystem::path& folder, const Sequence& seq)
+void store_step_setup_script(const std::filesystem::path& lua_file, const Sequence& seq)
 {
-    remove_path(folder);
+    remove_path(lua_file);
 
-    std::ofstream stream(folder);
+    std::ofstream stream(lua_file);
 
     if (not stream.is_open())
-        throw Error(gul14::cat("I/O error: unable to open file (", folder.string(), ")"));
+        throw Error(gul14::cat("I/O error: unable to open file (", lua_file.string(), ")"));
 
     stream << seq; // RAII closes the stream (let the destructor do the job)
 
@@ -176,7 +176,7 @@ void store_sequence(const std::filesystem::path& folder, const Sequence& seq)
         throw Error(gul14::cat("I/O error: ", e.what(), ", error=", std::strerror(err)));
     }
 
-    serialize_sequence_impl(seq_path / sequence_lua_filename, seq);
+    store_step_setup_script(seq_path / sequence_lua_filename, seq);
 
     for(const auto& step: seq)
         store_step(seq_path / extract_filename_step(++idx, max_digits, step), step);

--- a/src/serialize_sequence.cc
+++ b/src/serialize_sequence.cc
@@ -4,7 +4,7 @@
  * \date   Created on May 06, 2022
  * \brief  Implementation of the store_sequence() free function.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -125,14 +125,14 @@ std::ostream& operator<<(std::ostream& stream, const Step& step)
     return stream;
 }
 
-void store_step(const std::filesystem::path& folder, const Step& step)
+void store_step(const std::filesystem::path& lua_file, const Step& step)
 {
-    remove_path(folder);
+    remove_path(lua_file);
 
-    std::ofstream stream(folder);
+    std::ofstream stream(lua_file);
 
     if (not stream.is_open())
-        throw Error(gul14::cat("I/O error: unable to open file (", folder.string(), ")"));
+        throw Error(gul14::cat("I/O error: unable to open file (", lua_file.string(), ")"));
 
     stream << step; // RAII closes the stream (let the destructor do the job)
 }

--- a/src/serialize_sequence.cc
+++ b/src/serialize_sequence.cc
@@ -182,14 +182,4 @@ void store_sequence(const std::filesystem::path& folder, const Sequence& seq)
         store_step(seq_path / extract_filename_step(++idx, max_digits, step), step);
 }
 
-void serialize_step(const std::filesystem::path& folder, const Step& step)
-{
-    store_step(folder, step);
-}
-
-void serialize_sequence(const std::filesystem::path& folder, const Sequence& sequence)
-{
-    store_sequence(folder, sequence);
-}
-
 } // namespace task

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -77,8 +77,8 @@ TEST_CASE("Get sequence names", "[SequenceManager]")
     seq_2.push_back(step_1_01);
     seq_2.push_back(step_1_02);
 
-    serialize_sequence("unit_test_2", seq_1);
-    serialize_sequence("unit_test_2", seq_2);
+    store_sequence("unit_test_2", seq_1);
+    store_sequence("unit_test_2", seq_2);
 
     // create regular file to test sequence directory loading only.
     std::fstream f("unit_test_2/some_text_file.txt", std::ios::out);
@@ -126,7 +126,7 @@ TEST_CASE("Load sequence", "[SequenceManager]")
     SECTION("Simple path")
     {
         // store sequence to the default path '.'
-        serialize_sequence(".", seq);
+        store_sequence(".", seq);
 
         SequenceManager sm{"."};
         Sequence load = sm.load_sequence(sequence_name);
@@ -140,7 +140,7 @@ TEST_CASE("Load sequence", "[SequenceManager]")
     SECTION("Complex path")
     {
         // store sequence to the default path 'unit_test'
-        serialize_sequence("unit_test", seq);
+        store_sequence("unit_test", seq);
 
         SequenceManager sm{"unit_test"};
         Sequence load = sm.load_sequence(sequence_name);


### PR DESCRIPTION
[why]
Since there is a possibility to deserialize a step or sequence with the overload operator `operator>>` on a half filled object there is a need to reduce the deserialization functionality. To have a symmetrical view on serializing both operators `operator<<` on sequence and step are as well removed.

[how]
- removing input stream operator `operator>>` for sequence and step in [`deserialize_sequence.h`](https://github.com/taskolib/taskolib/compare/feature/downsize_serdes_functionality?expand=1#diff-c566f86b2558eccdb3e028bfa40bebb0bee25c88804fdc68ef94f597d5f88959)
- removing output stream operator `operator<<` for sequence and step in [`serialize_sequence.h`](https://github.com/taskolib/taskolib/compare/feature/downsize_serdes_functionality?expand=1#diff-6519b439c5fe3d34e95cd8f8bf23c53bf23f693b3358d59cb383ff67eb609326)
- remove test cases in [`test_serialize_sequence.cc`](https://github.com/taskolib/taskolib/compare/feature/downsize_serdes_functionality?expand=1#diff-1cabadad3e20032597594a44c63e0dd223457b40fd52dd2093f1784a5cadb102)where the four operators are used