### PR TITLE
Replace "LUA" by "Lua"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Taskolib Library
 
 The Taskolib library helps to automate processes. Its main automatization unit is a
 sequence of steps which are executed in order or through control flow statements. The
-behavior of each step is defined in the LUA scripting language.
+behavior of each step is defined in the Lua scripting language.
 
 The library API is documented with Doxygen on the web page
 https://taskolib.github.io/taskolib/ .

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -5,7 +5,7 @@
  *
  * Taskolib is a library for automating processes. Its main automatization unit is a
  * sequence of steps which are executed in order or through control flow statements. The
- * behavior of each step is defined in the LUA scripting language.
+ * behavior of each step is defined in the Lua scripting language.
  *
  * The library provides the main modeling classes for sequences and steps, functionality
  * for executing them in the current thread or in a parallel one, as well as serialization
@@ -122,14 +122,14 @@
  *
  * \section additional_copyright_notices Additional Copyright Notices
  *
- * This library contains a version of <a href="https://www.lua.org/">LUA</a> in the
+ * This library contains a version of <a href="https://www.lua.org/">Lua</a> in the
  * directory src/lua and a version of the <a href="https://github.com/ThePhD/sol2">Sol2</a>
  * library in the directory src/sol. Sol2 incorporates other open source software such as
  * the Ogonek library. Here are all of the copyright statements and licenses of the
  * individual components:
  *
  * <dl>
- * <dt>LUA</dt>
+ * <dt>Lua</dt>
  * <dd>Copyright (c) 1994–2021 Lua.org, PUC-Rio.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this

--- a/examples/execute_step.cc
+++ b/examples/execute_step.cc
@@ -19,7 +19,7 @@ int main()
     step.execute(context);
 
     // Retrieve variables from the context with std::get()
-    std::cout << "According to LUA, the sum of "
+    std::cout << "According to Lua, the sum of "
               << std::get<VarInteger>(context.variables["a"])
               << " and " << std::get<VarFloat>(context.variables["b"]) << " is "
               << std::get<VarFloat>(context.variables["sum"]) << ".\n";

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -91,7 +91,7 @@ using OutputCallback =
  * A context stores information that influences the execution of steps and sequences,
  * namely:
  * - A list of variables that can be im-/exported into steps.
- * - An initialization function that is called on a LUA state before a step is executed.
+ * - An initialization function that is called on a Lua state before a step is executed.
  * - Several callbacks that are invoked when a script calls print() or when the engine
  *   produces log output.
  *
@@ -109,7 +109,7 @@ struct Context
     /// Overwritten when a sequence is started.
     std::string step_setup_script = "";
 
-    /// An initialization function that is called on a LUA state before a step is executed.
+    /// An initialization function that is called on a Lua state before a step is executed.
     std::function<void(sol::state&)> step_setup_function;
 
     /// A callback that is invoked every time the script uses print().

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -252,13 +252,13 @@ public:
      * given by steps such as WHILE, IF, TRY, and so on. It returns when the sequence is
      * finished or has stopped with an error.
      *
-     * During execute(), is_running() returns true to internal functions or LUA callbacks.
+     * During execute(), is_running() returns true to internal functions or Lua callbacks.
      *
      * By executing the Sequence the step setup script overwrites
      * Context::step_setup_script.
      *
      * \param context A context for storing variables that can be exchanged between
-     *                different steps. The context may also contain a LUA init function
+     *                different steps. The context may also contain a Lua init function
      *                that is run before each step.
      * \param comm_channel  Pointer to a communication channel. If this is a null pointer,
      *                no messages are sent and no external interaction with the running

--- a/include/taskolib/Step.h
+++ b/include/taskolib/Step.h
@@ -272,12 +272,12 @@ private:
 
     /**
      * Copy the variables listed in used_context_variable_names_ from the given Context
-     * into a LUA state.
+     * into a Lua state.
      */
     void copy_used_variables_from_context_to_lua(const Context& context, sol::state& lua);
 
     /**
-     * Copy the variables listed in used_context_variable_names_ from a LUA state into the
+     * Copy the variables listed in used_context_variable_names_ from a Lua state into the
      * given Context.
      */
     void copy_used_variables_from_lua_to_context(const sol::state& lua, Context& context);

--- a/include/taskolib/sol/sol/config.hpp
+++ b/include/taskolib/sol/sol/config.hpp
@@ -30,7 +30,7 @@ https://sol2.readthedocs.io/en/latest/safety.html ! You can also pass them throu
 the build system, or the command line options of your compiler.
 */
 
-// Tell Sol3 that we are using a custom LUA build that was compiled with C++ and therefore
+// Tell Sol3 that we are using a custom Lua build that was compiled with C++ and therefore
 // properly handles exceptions.
 #define SOL_USING_CXX_LUA 1
 

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -94,7 +94,7 @@ std::string unescape_filename_characters(gul14::string_view str)
 }
 
 /**
- * Separate a comment line from a LUA script into a keyword and a remainder.
+ * Separate a comment line from a Lua script into a keyword and a remainder.
  *
  * "-- label: Hello" -> ["label", " Hello"]
  * "   -- label:Pippo " -> ["label", "Pippo "]

--- a/src/lua/meson.build
+++ b/src/lua/meson.build
@@ -1,4 +1,4 @@
-# Source files for our LUA library compiled as C++
+# Source files for our Lua library compiled as C++
 lua_sources = files(
     'lapi.cc',
     'lauxlib.cc',
@@ -34,7 +34,7 @@ lua_sources = files(
     'lzio.cc',
 )
 
-# Build LUA library
+# Build Lua library
 lua_lib = static_library(
     'lua',
     lua_sources,
@@ -45,7 +45,7 @@ lua_lib = static_library(
     include_directories : lua_inc,
 )
 
-# The generated static LUA library
+# The generated static Lua library
 # can be used via lua_dep
 lua_dep = declare_dependency(
     link_with : lua_lib,

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -2,7 +2,7 @@
  * \file   lua_details.cc
  * \author Lars Froehlich, Marcus Walla
  * \date   Created on June 15, 2022
- * \brief  Implementation of free functions dealing with LUA specifics.
+ * \brief  Implementation of free functions dealing with Lua specifics.
  *
  * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -61,7 +61,7 @@ void abort_script_with_error(lua_State* lua_state, const std::string& msg)
     // We store the error message in the registry...
     registry[abort_error_message_key] = gul14::cat(abort_marker, msg, abort_marker);
 
-    // ... and call the abort hook which raises a LUA error with the message from the
+    // ... and call the abort hook which raises a Lua error with the message from the
     // registry.
     hook_abort_with_error(lua_state, nullptr);
 }
@@ -94,7 +94,7 @@ void check_script_timeout(lua_State* lua_state)
 
     if (not timeout_ms.has_value())
     {
-        abort_script_with_error(lua_state, cat("Timeout time point not found in LUA "
+        abort_script_with_error(lua_state, cat("Timeout time point not found in Lua "
             "registry (", step_timeout_ms_since_epoch_key, ')'));
     }
     else
@@ -121,7 +121,7 @@ CommChannel* get_comm_channel_ptr_from_registry(lua_State* lua_state)
 
     sol::optional<CommChannel*> opt_comm_channel_ptr = registry[comm_channel_key];
     if (not opt_comm_channel_ptr.has_value())
-        throw Error(cat(comm_channel_key, " not found in LUA registry"));
+        throw Error(cat(comm_channel_key, " not found in Lua registry"));
 
     return *opt_comm_channel_ptr;
 }
@@ -133,7 +133,7 @@ OptionalStepIndex get_step_idx_from_registry(lua_State* lua_state)
 
     const sol::optional<LuaInteger> maybe_lua_step_idx = registry[step_index_key];
     if (not maybe_lua_step_idx.has_value())
-        throw Error(cat(step_index_key, " not found in LUA registry"));
+        throw Error(cat(step_index_key, " not found in Lua registry"));
 
     // The step index stored in the Lua registry is negative if it is not available.
     if (*maybe_lua_step_idx < 0)
@@ -164,9 +164,9 @@ LuaInteger get_ms_since_epoch(TimePoint t0, std::chrono::milliseconds dt)
 
 void hook_check_timeout_and_termination_request(lua_State* lua_state, lua_Debug*)
 {
-    // If necessary, these functions raise LUA errors to terminate the execution of the
-    // script. As we use a C++ compiled LUA, the error is thrown as an exception that is
-    // caught by a LUA-internal handler.
+    // If necessary, these functions raise Lua errors to terminate the execution of the
+    // script. As we use a C++ compiled Lua, the error is thrown as an exception that is
+    // caught by a Lua-internal handler.
     check_immediate_termination_request(lua_state);
     check_script_timeout(lua_state);
 }
@@ -200,7 +200,7 @@ void install_timeout_and_termination_request_hook(sol::state& lua, TimePoint now
     registry[step_index_key] = step_idx ? static_cast<LuaInteger>(*step_idx) : LuaInteger{ -1 };
     registry[comm_channel_key] = comm_channel;
 
-    // Install a hook that is called after every 100 LUA instructions
+    // Install a hook that is called after every 100 Lua instructions
     lua_sethook(lua, hook_check_timeout_and_termination_request, LUA_MASKCOUNT, 100);
 }
 

--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -2,7 +2,7 @@
  * \file   lua_details.h
  * \author Lars Froehlich, Marcus Walla
  * \date   Created on June 15, 2022
- * \brief  Declaration of free functions dealing with LUA specifics.
+ * \brief  Declaration of free functions dealing with Lua specifics.
  *
  * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -40,18 +40,18 @@ namespace task {
 static_assert(std::is_same<LuaFloat, double>::value, "Unexpected Lua-internal floating point type");
 static_assert(std::is_same<LuaInteger, long long>::value, "Unexpected Lua-internal integer type");
 
-// Abort the execution of the script by raising a LUA error with the given error message.
+// Abort the execution of the script by raising a Lua error with the given error message.
 void abort_script_with_error(lua_State* lua_state, const std::string& msg);
 
 // Check if immediate termination has been requested via the CommChannel. If so, raise a
-// LUA error.
+// Lua error.
 void check_immediate_termination_request(lua_State* lua_state);
 
-// Check if the step timeout has expired and raise a LUA error if that is the case.
+// Check if the step timeout has expired and raise a Lua error if that is the case.
 void check_script_timeout(lua_State* lua_state);
 
 /**
- * Retrieve a pointer to the used CommChannel from the LUA registry.
+ * Retrieve a pointer to the used CommChannel from the Lua registry.
  * The pointer can be null to indicate that no CommChannel is used.
  *
  * \exception Error is thrown if the appropriate registry key is not found.
@@ -76,17 +76,17 @@ OptionalStepIndex get_step_idx_from_registry(lua_State* lua_state);
 // returned.
 LuaInteger get_ms_since_epoch(TimePoint t0, std::chrono::milliseconds dt);
 
-// A LUA hook that stops the execution of the script by raising a LUA error.
+// A Lua hook that stops the execution of the script by raising a Lua error.
 // This hook reinstalls itself so that it is called immediately if the execution should
 // resume. This helps to break out of pcalls.
 void hook_abort_with_error(lua_State* lua_state, lua_Debug*);
 
 // Check if the step timeout has expired or if immediate termination has been requested
-// via the comm channel. If so, raise a LUA error.
+// via the comm channel. If so, raise a Lua error.
 void hook_check_timeout_and_termination_request(lua_State* lua_state, lua_Debug*);
 
 /**
- * Install implementations for some custom functions in the given LUA state.
+ * Install implementations for some custom functions in the given Lua state.
  * \code
  * print() -- print a string on the (virtual) console; this function calls the
  *            print_function callback from the given context
@@ -95,7 +95,7 @@ void hook_check_timeout_and_termination_request(lua_State* lua_state, lua_Debug*
  */
 void install_custom_commands(sol::state& lua, const Context& context);
 
-// Install hooks that check for timeouts and immediate termination requests while a LUA
+// Install hooks that check for timeouts and immediate termination requests while a Lua
 // script is being executed. If one of both occurs, the script terminates with an error
 // message that contains the abort marker.
 void install_timeout_and_termination_request_hook(sol::state& lua, TimePoint now,
@@ -107,7 +107,7 @@ std::function<void(sol::this_state, sol::variadic_args)>
 make_print_fct(
     std::function<void(const std::string&, OptionalStepIndex, CommChannel*)> print_fct);
 
-// Open a safe subset of the LUA standard libraries in the given LUA state.
+// Open a safe subset of the Lua standard libraries in the given Lua state.
 //
 // This opens the math, string, table, and UTF8 libraries. The base library is also
 // opened, but the following potentially dangerous commands are removed:

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -125,7 +125,7 @@ TEST_CASE("Executor: Run a failing sequence asynchronously", "[Executor]")
     context.log_error_function = nullptr;
 
     Step step(Step::type_action);
-    step.set_script("not valid LUA");
+    step.set_script("not valid Lua");
 
     Sequence sequence{ "test_sequence" };
     sequence.push_back(std::move(step));
@@ -200,7 +200,7 @@ TEST_CASE("Executor: Destruct while Lua script is running", "[Executor]")
     REQUIRE(sequence.get_error().has_value() == false);
 }
 
-TEST_CASE("Executor: cancel() within LUA sleep()", "[Executor]")
+TEST_CASE("Executor: cancel() within Lua sleep()", "[Executor]")
 {
     Context context;
     context.log_error_function = nullptr; // suppress error output on console

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -1286,7 +1286,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
     }
 }
 
-TEST_CASE("execute(): complex sequence with prohibited LUA function", "[Sequence]")
+TEST_CASE("execute(): complex sequence with prohibited Lua function", "[Sequence]")
 {
     Context context;
 

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -808,7 +808,7 @@ TEST_CASE("execute(): External commands on Lua scripts", "[Step]")
     }
 }
 
-TEST_CASE("execute(): LUA initialization function", "[Step]")
+TEST_CASE("execute(): Lua initialization function", "[Step]")
 {
     Context context;
     context.variables["a"] = VarInteger{ 41 };


### PR DESCRIPTION
*[why]*
To cite from https://www.lua.org/about.html:
> "Lua" (pronounced LOO-ah) means "Moon" in Portuguese. As such, it is neither an acronym nor an abbreviation, but a noun. More specifically, "Lua" is a name, the name of the Earth's moon and the name of the language. Like most names, it should be written in lower case with an initial capital, that is, "Lua". Please do not write it as "LUA", which is both ugly and confusing, because then it becomes an acronym with different meanings for different people. So, please, write "Lua" right!