### PR TITLE
Execute single step in isolation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "(gdb) Debug Test",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/builddir/taskolib_test",
+            "program": "${workspaceFolder}/builddir/tests/taskolib_test",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
@@ -20,7 +20,9 @@
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
                 }
-            ]
+            ],
+            "preLaunchTask": "Meson: Build all targets"
+
         },
         {
             "name": "(gdb) Debug run_lua Playground",

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -651,13 +651,13 @@ private:
      * \param step_begin Iterator to the first step that should be executed
      * \param step_end   Iterator past the last step that should be executed
      * \param context    Context for executing the steps
-     * \param comm     Pointer to a communication channel; if null, messaging and
-     *                 cross-thread interaction are disabled.
+     * \param comm       Pointer to a communication channel; if null, messaging and
+     *                   cross-thread interaction are disabled.
      * \exception Error is thrown if the execution fails at some point.
      */
     Iterator
-    execute_sequence_impl(Iterator step_begin, Iterator step_end, Context& context,
-                          CommChannel* comm);
+    execute_range(Iterator step_begin, Iterator step_end, Context& context,
+                  CommChannel* comm);
 
     /**
      * Execute a TRY block.

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -301,7 +301,7 @@ void Sequence::execute(Context& context, CommChannel* comm)
     try
     {
         check_syntax();
-        execute_sequence_impl(steps_.begin(), steps_.end(), context, comm);
+        execute_range(steps_.begin(), steps_.end(), context, comm);
     }
     catch (const Error& e)
     {
@@ -351,7 +351,7 @@ Sequence::execute_else_block(Iterator begin, Iterator end, Context& context,
     const auto block_end = find_end_of_indented_block(
         begin + 1, end, begin->get_indentation_level() + 1);
 
-    execute_sequence_impl(begin + 1, block_end, context, comm);
+    execute_range(begin + 1, block_end, context, comm);
 
     return block_end;
 }
@@ -365,7 +365,7 @@ Sequence::execute_if_or_elseif_block(Iterator begin, Iterator end, Context& cont
 
     if (begin->execute(context, comm, begin - steps_.begin()))
     {
-        execute_sequence_impl(begin + 1, block_end, context, comm);
+        execute_range(begin + 1, block_end, context, comm);
 
         // Skip forward past the END
         auto end_it = std::find_if(block_end, end,
@@ -383,7 +383,7 @@ Sequence::execute_if_or_elseif_block(Iterator begin, Iterator end, Context& cont
 }
 
 Sequence::Iterator
-Sequence::execute_sequence_impl(Iterator step_begin, Iterator step_end, Context& context,
+Sequence::execute_range(Iterator step_begin, Iterator step_end, Context& context,
                                 CommChannel* comm)
 {
     Iterator step = step_begin;
@@ -449,7 +449,7 @@ Sequence::execute_try_block(Iterator begin, Iterator end, Context& context,
 
     try
     {
-        execute_sequence_impl(begin + 1, it_catch, context, comm);
+        execute_range(begin + 1, it_catch, context, comm);
     }
     catch (const Error& e)
     {
@@ -458,7 +458,7 @@ Sequence::execute_try_block(Iterator begin, Iterator end, Context& context,
         if (gul14::contains(e.what(), abort_marker))
             throw;
 
-        execute_sequence_impl(it_catch + 1, it_catch_block_end, context, comm);
+        execute_range(it_catch + 1, it_catch_block_end, context, comm);
     }
 
     return it_catch_block_end;
@@ -472,7 +472,7 @@ Sequence::execute_while_block(Iterator begin, Iterator end, Context& context,
         begin + 1, end, begin->get_indentation_level() + 1);
 
     while (begin->execute(context, comm, begin - steps_.begin()))
-        execute_sequence_impl(begin + 1, block_end, context, comm);
+        execute_range(begin + 1, block_end, context, comm);
 
     return block_end + 1;
 }

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -395,8 +395,12 @@ Sequence::execute_range(Iterator step_begin, Iterator step_end, Context& context
             ++step;
             continue;
         }
+
         if (comm and comm->immediate_termination_requested_)
-            throw Error{ gul14::cat(abort_marker, "Stop on user request") , step - steps_.begin() };
+        {
+            throw Error{ gul14::cat(abort_marker, "Stop on user request"),
+                         static_cast<StepIndex>(step - steps_.begin()) };
+        }
 
         switch (step->get_type())
         {


### PR DESCRIPTION
This PR implements single-step execution in the `Sequence` class.

*[why]*
Executing single steps in isolation is extremely important for debugging.

*[how]*
Add a member function
```cpp
execute_single_step(Context&, CommChannel*, StepIndex) 
```
similar to the existing
```cpp
execute(Context&, CommChannel*)
```
The functions share their main implementation through a private member function `handle_execution()`, which takes care of exception handling and messaging. In a nutshell, `execute()` runs a body of
```cpp
check_syntax();
execute_range(...);
```
whereas `execute_single_step()` runs a body of
```
if (executes_script(step->get_type()))
    step->execute(context, comm, step_index);
```

Drive-by commits include renaming a member function, silencing a compiler warning, and some corrections for VScode.

Closes #61.