### PR TITLE
Sequence: Remove execute_single_step() in favor of execute()

### DIFF
--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -246,60 +246,44 @@ public:
     ConstIterator erase(ConstIterator begin, ConstIterator end);
 
     /**
-     * Execute the sequence within a given context.
+     * Execute the sequence (or just one of its steps) within a given context.
      *
-     * This function first performs a syntax check and throws an Error exception if it
-     * fails. Then, it executes the sequence step by step, following the control flow
-     * given by steps such as WHILE, IF, TRY, and so on. It returns when the sequence is
-     * finished or has stopped with an error.
+     * Depending on the value of the opt_step_index parameter, this function either runs
+     * the entire sequence or just one of its steps:
+     *
+     * - If `opt_step_index == nullopt`, the function first performs a syntax check and
+     *   throws an Error exception if it fails. Then, it executes the sequence step by
+     *   step, following the control flow given by steps such as WHILE, IF, TRY, and so
+     *   on. Disabled steps are ignored. The function returns when the sequence has
+     *   finished or has stopped with an error.
+     *
+     * - If `opt_step_index` contains a step index, this function executes the single step
+     *   identified by the index. As usual, both the step setup function (from the
+     *   context) and the step setup script (from the sequence) are run before the step
+     *   script. No verification of the entire sequence takes place, so that a single step
+     *   can even be run if the logical structure of the sequence is faulty. For most
+     *   other intents and purposes, running a single step behaves like running the entire
+     *   sequence.
      *
      * During execute(), is_running() returns true to internal functions or Lua callbacks.
      *
-     * By executing the Sequence the step setup script overwrites
-     * Context::step_setup_script.
-     *
      * \param context  A Context for storing variables, step setup information and other
-     *                 data relevant for the execution
+     *                 data relevant for the execution. The `step_setup_script` member is
+     *                 overwritten with the step setup script of the executed sequence.
      * \param comm_channel  Pointer to a communication channel. If this is a null pointer,
      *                 no messages are sent and no external interaction with the running
      *                 sequence is possible. Otherwise, messages for starting/stopping
      *                 steps and the sequence itself are sent and termination requests are
      *                 honored.
+     * \param opt_step_index  Index of the step to be executed
      *
      * \exception Error is thrown if the script cannot be executed due to a syntax error
      *            or if it raises an error during execution. In these cases, the error
      *            message is also stored in the Sequence object and can be retrieved with
      *            get_error_message().
      */
-    void execute(Context& context, CommChannel* comm_channel);
-
-    /**
-     * Execute a single step of this sequence in isolation.
-     *
-     * This function executes a single step identified by its index. As usual, both the
-     * step setup function (from the context) and the step setup script (from the
-     * sequence) are run before the step script. Contrary to `execute()`, no verification
-     * of the entire sequence takes place, so that a single step can even be run if the
-     * logical structure of the sequence is faulty. For most other intents and purposes,
-     * running a single step behaves like running the entire sequence.
-     *
-     * Like execute(), this function overwrites `context.step_setup_script`.
-     *
-     * \param context  A Context for storing variables, step setup information and other
-     *                 data relevant for the execution
-     * \param comm_channel  Pointer to a communication channel. If this is a null pointer,
-     *                 no messages are sent and no external interaction with the running
-     *                 sequence is possible. Otherwise, messages for starting/stopping
-     *                 the step are sent and termination requests are honored.
-     * \param step_index  Index of the step to be executed
-     *
-     * \exception Error is thrown if the step index is invalid, if the step cannot be
-     *            executed due to a Lua syntax error or if it raises an error during
-     *            execution. In these cases, the error message is also stored in the
-     *            Sequence object and can be retrieved with get_error_message().
-     */
-    void execute_single_step(Context& context, CommChannel* comm_channel,
-                             StepIndex step_index);
+    void execute(Context& context, CommChannel* comm_channel,
+                 OptionalStepIndex opt_step_index = gul14::nullopt);
 
     /**
      * Return an optional Error object explaining why the sequence stopped prematurely.

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -41,20 +41,17 @@ namespace {
 // sequence. If step_index contains a step index, it calls
 // Sequence::execute_single_step(). In both cases, all exceptions are silently
 //
-// \param sequence    The Sequence to be started
-// \param context     The Context under which the sequence should run
-// \param comm        Shared pointer to a CommChannel for communication (can be null)
-// \param step_index  The index of the step to be started in isolation or nullopt to start
-//                    the entire sequence
+// \param sequence        The Sequence to be started
+// \param context         The Context under which the sequence should run
+// \param comm            Shared pointer to a CommChannel for communication (can be null)
+// \param opt_step_index  The index of the step to be started in isolation or nullopt to
+//                        start the entire sequence
 VariableTable execute_sequence(Sequence sequence, Context context,
-    std::shared_ptr<CommChannel> comm, OptionalStepIndex step_index) noexcept
+    std::shared_ptr<CommChannel> comm, OptionalStepIndex opt_step_index) noexcept
 {
     try
     {
-        if (step_index)
-            sequence.execute_single_step(context, comm.get(), *step_index);
-        else
-            sequence.execute(context, comm.get());
+        sequence.execute(context, comm.get(), opt_step_index);
     }
     catch (const std::exception&)
     {

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -3545,7 +3545,7 @@ TEST_CASE("execute(): Disable + re-enable action inside while loop", "[Sequence]
     }
 }
 
-TEST_CASE("execute_single_step()", "[Sequence]")
+TEST_CASE("execute(): Single step", "[Sequence]")
 {
     // A deliberately invalid sequence for testing single-step execution:
     // END
@@ -3574,26 +3574,26 @@ TEST_CASE("execute_single_step()", "[Sequence]")
 
     SECTION("Index 0 (END step): Script is not executed because of the step type")
     {
-        sequence.execute_single_step(context, nullptr, 0);
+        sequence.execute(context, nullptr, 0);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 0 });
     }
 
     SECTION("Index 1 (WHILE step): Script is executed")
     {
-        sequence.execute_single_step(context, nullptr, 1);
+        sequence.execute(context, nullptr, 1);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 2 });
     }
 
     SECTION("Index 2 (ACTION step): Script is executed")
     {
-        REQUIRE_THROWS_WITH(sequence.execute_single_step(context, nullptr, 2),
+        REQUIRE_THROWS_WITH(sequence.execute(context, nullptr, 2),
                             Contains("Action Boom"));
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 3 });
     }
 
     SECTION("Invalid index")
     {
-        REQUIRE_THROWS_AS(sequence.execute_single_step(context, nullptr, 3), Error);
+        REQUIRE_THROWS_AS(sequence.execute(context, nullptr, 3), Error);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 0 });
     }
 }


### PR DESCRIPTION
As proposed by Fini in #63, this commit replaces the two Sequence member functions
```cpp
void execute(Context& context, CommChannel* comm_channel);
void execute_single_step(Context& context, CommChannel* comm_channel, StepIndex step_index);
```
by a single one:
```
void execute(Context& context, CommChannel* comm_channel, OptionalStepIndex opt_step_index = gul14::nullopt);
```
The new `execute()` function runs the entire sequence if `opt_step_index == nullopt`, and runs just a single step in isolation if `opt_step_index` contains a valid step index.

IMO the new interface does not convey the user's intent just as well as the old one, so I would tend to keep the old API. It still has its merits to have one less member function. Please let me know what you think.