### PR TITLE
Make Sequence::execute return optional<Error> instead of throwing

### DIFF
--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -277,13 +277,14 @@ public:
      *                 honored.
      * \param opt_step_index  Index of the step to be executed
      *
-     * \exception Error is thrown if the script cannot be executed due to a syntax error
-     *            or if it raises an error during execution. In these cases, the error
-     *            message is also stored in the Sequence object and can be retrieved with
-     *            get_error_message().
+     * \returns nullopt if the execution finished successfully, or an Error object if the
+     *          script cannot be executed due to a syntax error or if it raises an error
+     *          during execution. The return value is also stored in the Sequence object
+     *          and can be retrieved with get_error_message().
      */
-    void execute(Context& context, CommChannel* comm_channel,
-                 OptionalStepIndex opt_step_index = gul14::nullopt);
+    [[nodiscard]]
+    gul14::optional<Error> execute(Context& context, CommChannel* comm_channel,
+                                   OptionalStepIndex opt_step_index = gul14::nullopt);
 
     /**
      * Return an optional Error object explaining why the sequence stopped prematurely.
@@ -728,8 +729,12 @@ private:
      * \param exec_block_name  Name of the execution block, preferably starting with a
      *                      capital letter (e.g. "Sequence", "Single-step execution")
      * \param runner        Function to be executed
+     *
+     * \returns nullopt if the execution function finished successfully, or an Error
+     *          object if anything went wrong.
      */
-    void
+    [[nodiscard]]
+    gul14::optional<Error>
     handle_execution(Context& context, CommChannel* comm_channel,
                      gul14::string_view exec_block_name,
                      std::function<void(Context&, CommChannel*)> runner);

--- a/include/taskolib/exceptions.h
+++ b/include/taskolib/exceptions.h
@@ -25,7 +25,7 @@
 #ifndef TASKOLIB_EXCEPTIONS_H_
 #define TASKOLIB_EXCEPTIONS_H_
 
-#include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -84,6 +84,19 @@ public:
 
     /// Return the associated step index.
     OptionalStepIndex get_index() const { return index_; }
+
+    /// Determine if two Error objects have the same content.
+    friend bool operator==(const Error& lhs, const Error& rhs) noexcept
+    {
+        return (std::strcmp(lhs.what(), rhs.what()) == 0)
+            && lhs.index_ == rhs.index_;
+    }
+
+    /// Determine if two Error objects have different content.
+    friend bool operator!=(const Error& lhs, const Error& rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
 
 private:
     OptionalStepIndex index_;

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -49,15 +49,10 @@ namespace {
 VariableTable execute_sequence(Sequence sequence, Context context,
     std::shared_ptr<CommChannel> comm, OptionalStepIndex opt_step_index) noexcept
 {
-    try
-    {
-        sequence.execute(context, comm.get(), opt_step_index);
-    }
-    catch (const std::exception&)
-    {
-        // Silently ignore any thrown exception - the sequence already takes care of
-        // sending the appropriate messages.
-    }
+    // Ignore any returned errors - the sequence already takes care of sending the
+    // appropriate messages.
+    (void)sequence.execute(context, comm.get(), opt_step_index);
+
     return context.variables;
 }
 

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -425,7 +425,7 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
         seq.modify(s, [](Step& step) { step.set_used_context_variable_names(VariableNames{ "a" }); });
 
     // Execute directly
-    seq.execute(ctx, nullptr);
+    REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
     REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 11 );
 
     // Execute async
@@ -526,15 +526,9 @@ TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
     seq.push_back(step);
 
     // I. direct execution
-
-    REQUIRE_THROWS_AS(seq.execute(ctx, nullptr), task::Error);
-    try {
-        seq.execute(ctx, nullptr);
-    } catch (task::Error const& e) {
-        INFO("what is:");
-        INFO(e.what());
-        REQUIRE(gul14::contains(e.what(), "Rainbows"));
-    }
+    auto maybe_error = seq.execute(ctx, nullptr);
+    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE_THAT(maybe_error->what(), Contains("Rainbows"));
 
     // II. run async
     Executor executor{ };

--- a/tests/test_exceptions.cc
+++ b/tests/test_exceptions.cc
@@ -66,3 +66,27 @@ TEST_CASE("Error: Copy assignment", "[exceptions]")
     REQUIRE(e2.what() == "Test"s);
     REQUIRE(e2.get_index() == e.get_index());
 }
+
+TEST_CASE("Error: operator==", "[exceptions]")
+{
+    REQUIRE(Error("Test", 42) == Error("Test", 42));
+    REQUIRE(Error("Test", gul14::nullopt) == Error("Test", gul14::nullopt));
+    REQUIRE(Error("", 42) == Error("", 42));
+
+    REQUIRE_FALSE(Error("test", 42) == Error("TEST", 42));
+    REQUIRE_FALSE(Error("test", 42) == Error("test", 23));
+    REQUIRE_FALSE(Error("Test", 13) == Error("Test", gul14::nullopt));
+    REQUIRE_FALSE(Error(" ", gul14::nullopt) == Error("", gul14::nullopt));
+}
+
+TEST_CASE("Error: operator!=", "[exceptions]")
+{
+    REQUIRE_FALSE(Error("Test", 42) != Error("Test", 42));
+    REQUIRE_FALSE(Error("Test", gul14::nullopt) != Error("Test", gul14::nullopt));
+    REQUIRE_FALSE(Error("", 42) != Error("", 42));
+
+    REQUIRE(Error("test", 42) != Error("TEST", 42));
+    REQUIRE(Error("test", 42) != Error("test", 23));
+    REQUIRE(Error("Test", 13) != Error("Test", gul14::nullopt));
+    REQUIRE(Error(" ", gul14::nullopt) != Error("", gul14::nullopt));
+}


### PR DESCRIPTION
This PR makes `Sequence::execute()` return an `optional<Error>` instead of throwing. For improved testing, it also adds comparison operators to the `Error` class.

*[why]*
In virtually all cases in our codebase, exceptions thrown from `Sequence::execute()` were caught immediately with a try...catch block. In this case it makes, arguably, no sense to throw an exception, and returning an optional error directly results in more readable code.
    
As a side effect, the value returned from `Sequence::execute()` is now identical to what gets returned from `Sequence::get_error()` afterwards. This symmetry was simply not visible before.
