### PR TITLE
Add messaging hooks and rework callback architecture

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,8 +1,8 @@
 # Headers to be installed under ${prefix}/include/
 public_headers = [
    'taskolib/CommChannel.h',
-   'taskolib/console.h',
    'taskolib/Context.h',
+   'taskolib/default_message_callback.h',
    'taskolib/deserialize_sequence.h',
    'taskolib/exceptions.h',
    'taskolib/execute_lua_script.h',

--- a/include/taskolib/CommChannel.h
+++ b/include/taskolib/CommChannel.h
@@ -2,9 +2,9 @@
  * \file   CommChannel.h
  * \author Lars Froehlich
  * \date   Created on June 8, 2022
- * \brief  Declaration of the CommChannel struct and of the send_message() function.
+ * \brief  Declaration of the CommChannel struct.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,11 +27,8 @@
 
 #include <atomic>
 
-#include <gul14/string_view.h>
-
 #include "taskolib/LockedQueue.h"
 #include "taskolib/Message.h"
-#include "taskolib/StepIndex.h"
 
 namespace task {
 
@@ -47,33 +44,6 @@ struct CommChannel
     LockedQueue<Message> queue_{ 32 };
     std::atomic<bool> immediate_termination_requested_{ false };
 };
-
-/**
- * Enqueue a message in the given communication channel.
- *
- * \param comm_channel  Pointer to the communication channel. If this is null, the
- *                   function does nothing.
- * \param type       Message type (see Message::Type)
- * \param text       Message text
- * \param timestamp  Timestamp of the message
- * \param index      An optional index (of a Step in its parent Sequence)
- *
- * \code
- * send_message(comm_channel, type, text, timestamp, index);
- * // ... is equivalent to:
- * if (comm_channel)
- *     comm_channel->queue_.push(Message(type, text, timestamp, index));
- * \endcode
- */
-inline
-void send_message(CommChannel* comm_channel, Message::Type type, gul14::string_view text,
-                  TimePoint timestamp, OptionalStepIndex index)
-{
-    if (comm_channel == nullptr)
-        return;
-
-    comm_channel->queue_.push(Message(type, std::string(text), timestamp, index));
-}
 
 } // namespace task
 

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -32,7 +32,7 @@
 
 #include "sol/sol.hpp"
 #include "taskolib/CommChannel.h"
-#include "taskolib/console.h"
+#include "taskolib/default_message_callback.h"
 #include "taskolib/Message.h"
 #include "taskolib/StepIndex.h"
 #include "taskolib/VariableName.h"
@@ -80,25 +80,49 @@ using VariableValue = std::variant<
 using VariableTable = std::unordered_map<VariableName, VariableValue>;
 
 /**
- * An output function accepts a string, an optional step index, and a CommChannel* as
- * parameters. The latter may be null to indicate that there is no associated
- * communication channel.
+ * A message callback function receives a Message object as a parameter. It is called on
+ * the main thread whenever a message is being processed.
  */
-using OutputCallback =
-    std::function<void(const std::string&, OptionalStepIndex, CommChannel*)>;
+using MessageCallback = std::function<void(const Message&)>;
 
 /**
  * A context stores information that influences the execution of steps and sequences,
  * namely:
  * - A list of variables that can be im-/exported into steps.
- * - An initialization function that is called on a Lua state before a step is executed.
- * - Several callbacks that are invoked when a script calls print() or when the engine
- *   produces log output.
+ * - An initialization function (in C++) that is called on a Lua state before a step is
+ *   executed.
+ * - A step setup script (in Lua) that is executed before a step is executed. Global
+ *   variables and functions defined in this step setup script can be accessed by the Lua
+ *   script in the step. When a sequence is executed, this step setup script is
+ *   overwritten with the one from the sequence.
+ * - A callback that is invoked whenever a message is being processed by the execution
+ *   engine (see below for details).
  *
- * Global variables and functions defined in the step setup script can be accessed.
+ * <h3>Message callback function</h3>
  *
- * Be aware that step setup script is overwritten with the content of the sequence setup
- * script during its execution.
+ * The Context contains a message_callback_function that is called once for each message
+ * that is being processed by the execution engine in the main thread. By default, this
+ * function will send the output of the Lua "print()" command and error messages to
+ * stdout (see default_message_callback()). However, message_callback_function can also be
+ * set to nullptr (to disable any special behavior) or to a custom function:
+ * \code
+ * void my_message_callback(const Message& msg)
+ * {
+ *     if (msg.get_type() == Message::Type::output)
+ *         send_to_console(msg.get_text());
+ *     else if (msg.get_type() == Message::Type::sequence_stopped_with_error)
+ *         show_alert_box(msg.get_text());
+ * }
+ *
+ * Context context;
+ * context.message_callback_function = my_message_callback;
+ * \endcode
+ * The callback function receives a reference to the message that is being processed.
+ * If a sequence is executed in the current thread (e.g. via Sequence::execute()), the
+ * callback is executed whenever a message is generated. If the sequence is handed to an
+ * Executor for parallel execution, the callback is run whenever the main thread has
+ * received the message (i.e. typically within Executor::update()). Callbacks are never
+ * executed on the worker thread.
  */
 struct Context
 {
@@ -112,11 +136,11 @@ struct Context
     /// An initialization function that is called on a Lua state before a step is executed.
     std::function<void(sol::state&)> step_setup_function;
 
-    /// A callback that is invoked every time the script uses print().
-    OutputCallback print_function = print_to_stdout;
-
-    /// A callback that is invoked for error log messages.
-    OutputCallback log_error_function = print_error_to_stdout;
+    /**
+     * A callback (or "hook") function that is invoked whenever a message is processed
+     * during the execution of a sequence.
+     */
+    MessageCallback message_callback_function = default_message_callback;
 };
 
 } // namespace task

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -4,7 +4,7 @@
  * \date   Created on December 20, 2021
  * \brief  Declaration of the Context and VariableValue types.
  *
- * \copyright Copyright 2021-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -114,9 +114,6 @@ struct Context
 
     /// A callback that is invoked every time the script uses print().
     OutputCallback print_function = print_to_stdout;
-
-    /// A callback that is invoked for warning log messages.
-    OutputCallback log_warning_function = print_warning_to_stdout;
 
     /// A callback that is invoked for error log messages.
     OutputCallback log_error_function = print_error_to_stdout;

--- a/include/taskolib/Context.h
+++ b/include/taskolib/Context.h
@@ -115,9 +115,6 @@ struct Context
     /// A callback that is invoked every time the script uses print().
     OutputCallback print_function = print_to_stdout;
 
-    /// A callback that is invoked for informational log messages.
-    OutputCallback log_info_function = print_info_to_stdout;
-
     /// A callback that is invoked for warning log messages.
     OutputCallback log_warning_function = print_warning_to_stdout;
 

--- a/include/taskolib/Executor.h
+++ b/include/taskolib/Executor.h
@@ -4,7 +4,7 @@
  * \date   Created on May 30, 2022
  * \brief  Declaration of the Executor class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -80,9 +80,6 @@ namespace task {
  *
  *     /// A callback that is invoked every time the script uses print().
  *     OutputCallback print_function = print_to_stdout;
- *
- *     /// A callback that is invoked for warning log messages.
- *     OutputCallback log_warning_function = print_warning_to_stdout;
  *
  *     /// A callback that is invoked for error log messages.
  *     OutputCallback log_error_function = print_error_to_stdout;

--- a/include/taskolib/Executor.h
+++ b/include/taskolib/Executor.h
@@ -81,9 +81,6 @@ namespace task {
  *     /// A callback that is invoked every time the script uses print().
  *     OutputCallback print_function = print_to_stdout;
  *
- *     /// A callback that is invoked for informational log messages.
- *     OutputCallback log_info_function = print_info_to_stdout;
- *
  *     /// A callback that is invoked for warning log messages.
  *     OutputCallback log_warning_function = print_warning_to_stdout;
  *

--- a/include/taskolib/Executor.h
+++ b/include/taskolib/Executor.h
@@ -65,39 +65,6 @@ namespace task {
  * worker thread can make progress. This is because the message queue for communication
  * between the threads has only a limited capacity, and execution is paused once it is
  * full. Only calls to update() take messages out of the queue again.
- *
- * <h3>The Context and its output functions</h3>
- *
- * The sequence can produce (virtual) console output and logging messages of various
- * kinds. The user can set several callback functions in the Context to determine what to
- * do with this output:
- * \code
- * using OutputCallback = std::function<void(const std::string&, CommChannel*)>;
- *
- * struct Context
- * {
- *     // ...
- *
- *     /// A callback that is invoked every time the script uses print().
- *     OutputCallback print_function = print_to_stdout;
- *
- *     /// A callback that is invoked for error log messages.
- *     OutputCallback log_error_function = print_error_to_stdout;
- * };
- * \endcode
- * From a user perspective, these functions only need a string argument to do their job.
- * Under the hood, however, things get a little tricky when a sequence is run in a
- * parallel thread because that thread may not invoke the callback functions directly due
- * to lack of inter-thread synchronization. What happens instead is the following:
- *
- * - The Executor makes a copy of the Context for the parallel thread.
- * - In that Context copy, it replaces the callback functions by versions that send
- *   appropriate messages via a message queue (CommChannel) instead.
- * - The Executor receives these messages and takes care about calling the original user
- *   callbacks in the main thread.
- *
- * This also explains why there is a second argument in the OutputCallback function
- * signature. User code should generally ignore it.
  */
 class Executor
 {

--- a/include/taskolib/Message.h
+++ b/include/taskolib/Message.h
@@ -48,7 +48,6 @@ public:
     enum class Type
     {
         output, ///< a message string that was output by a step via print()
-        log_warning, ///< a log entry carrying some kind of warning
         log_error, ///< a log entry carrying an error message
         sequence_started, ///< a sequence has been started
         sequence_stopped, ///< a sequence has stopped regularly
@@ -64,7 +63,6 @@ private:
     type_description_ =
     {
         "output",
-        "log_warning",
         "log_error",
         "sequence_started",
         "sequence_stopped",

--- a/include/taskolib/Message.h
+++ b/include/taskolib/Message.h
@@ -48,7 +48,6 @@ public:
     enum class Type
     {
         output, ///< a message string that was output by a step via print()
-        log_info, ///< a log entry of informational character
         log_warning, ///< a log entry carrying some kind of warning
         log_error, ///< a log entry carrying an error message
         sequence_started, ///< a sequence has been started
@@ -61,10 +60,10 @@ public:
     };
 
 private:
-    static constexpr std::array<char const*, static_cast<int>(Type::undefined) + 1> type_description_ =
+    static constexpr std::array<char const*, static_cast<int>(Type::undefined) + 1>
+    type_description_ =
     {
         "output",
-        "log_info",
         "log_warning",
         "log_error",
         "sequence_started",

--- a/include/taskolib/Message.h
+++ b/include/taskolib/Message.h
@@ -48,7 +48,6 @@ public:
     enum class Type
     {
         output, ///< a message string that was output by a step via print()
-        log_error, ///< a log entry carrying an error message
         sequence_started, ///< a sequence has been started
         sequence_stopped, ///< a sequence has stopped regularly
         sequence_stopped_with_error, ///< a sequence has been stopped because of an error
@@ -63,7 +62,6 @@ private:
     type_description_ =
     {
         "output",
-        "log_error",
         "sequence_started",
         "sequence_stopped",
         "sequence_stopped_with_error",

--- a/include/taskolib/default_message_callback.h
+++ b/include/taskolib/default_message_callback.h
@@ -1,10 +1,10 @@
 /**
- * \file   console.h
+ * \file   default_message_callback.h
  * \author Lars Froehlich
  * \date   Created on June 22, 2022
- * \brief  Declaration of several functions for console output.
+ * \brief  Declaration of the default_message_callback() function.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,28 +27,18 @@
 
 #include <string>
 
-#include "taskolib/StepIndex.h"
 #include "taskolib/Message.h"
 
 namespace task {
 
 struct CommChannel;
 
-/// Print a string to stdout.
-void print_to_stdout(const std::string& str, OptionalStepIndex,
-                     CommChannel* comm_channel);
-
-/// Print a string to stdout with an "INFO: " prefix.
-void print_info_to_stdout(const std::string& str, OptionalStepIndex,
-                          CommChannel* comm_channel);
-
-/// Print a string to stdout with a "WARNING: " prefix.
-void print_warning_to_stdout(const std::string& str, OptionalStepIndex,
-                             CommChannel* comm_channel);
-
-/// Print a string to stdout with an "ERROR: " prefix.
-void print_error_to_stdout(const std::string& str, OptionalStepIndex,
-                           CommChannel* comm_channel);
+/**
+ * Default callback function for messages.
+ *
+ * It sends "output" messages to stdout. All other message types are ignored.
+ */
+void default_message_callback(const Message& msg);
 
 } // namespace task
 

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -65,7 +65,7 @@ void print_to_message_queue(const std::string& text, OptionalStepIndex idx,
 void log_error_to_message_queue(const std::string& text, OptionalStepIndex idx,
                                 CommChannel* comm_channel)
 {
-    send_message(comm_channel, Message::Type::log_error, text, Clock::now(), idx);
+    send_message(comm_channel, Message::Type::output, text, Clock::now(), idx);
 }
 
 } // anonymous namespace
@@ -170,10 +170,6 @@ bool Executor::update(Sequence& sequence)
         case Message::Type::output:
             if (context_.print_function)
                 context_.print_function(msg.get_text(), step_idx, nullptr);
-            break;
-        case Message::Type::log_error:
-            if (context_.log_error_function)
-                context_.log_error_function(msg.get_text(), step_idx, nullptr);
             break;
         case Message::Type::sequence_started:
             break;

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -56,18 +56,6 @@ VariableTable execute_sequence(Sequence sequence, Context context,
     return context.variables;
 }
 
-void print_to_message_queue(const std::string& text, OptionalStepIndex idx,
-                            CommChannel* comm_channel)
-{
-    send_message(comm_channel, Message::Type::output, text, Clock::now(), idx);
-}
-
-void log_error_to_message_queue(const std::string& text, OptionalStepIndex idx,
-                                CommChannel* comm_channel)
-{
-    send_message(comm_channel, Message::Type::output, text, Clock::now(), idx);
-}
-
 } // anonymous namespace
 
 
@@ -120,9 +108,8 @@ void Executor::launch_async_execution(Sequence& sequence, Context context,
     // Store a copy of the context for its local print and logging functions
     context_ = context;
 
-    // Redirect the output functions used by the parallel thread to the message queue
-    context.print_function = print_to_message_queue;
-    context.log_error_function = log_error_to_message_queue;
+    // Disable any message callbacks in the worker thread
+    context.message_callback_function = nullptr;
 
     future_ = std::async(std::launch::async, execute_sequence, sequence,
                          std::move(context), comm_channel_, step_index);
@@ -165,22 +152,21 @@ bool Executor::update(Sequence& sequence)
                 sequence.set_running(was_running);
             };
 
+        if (context_.message_callback_function)
+            context_.message_callback_function(msg);
+
         switch (msg.get_type())
         {
         case Message::Type::output:
-            if (context_.print_function)
-                context_.print_function(msg.get_text(), step_idx, nullptr);
-            break;
+            break; // only triggers callback
         case Message::Type::sequence_started:
-            break;
+            break; // only triggers callback
         case Message::Type::sequence_stopped:
             sequence.set_running(false);
             break;
         case Message::Type::sequence_stopped_with_error:
             sequence.set_running(false);
             sequence.set_error(Error{ msg.get_text(), msg.get_index() });
-            if (context_.log_error_function)
-                context_.log_error_function(msg.get_text(), step_idx, nullptr);
             break;
         case Message::Type::step_started:
             modify_step([ts = msg.get_timestamp()](Step& s)
@@ -194,8 +180,6 @@ bool Executor::update(Sequence& sequence)
             break;
         case Message::Type::step_stopped_with_error:
             modify_step([](Step& s) { s.set_running(false); });
-            if (context_.log_error_function)
-                context_.log_error_function(msg.get_text(), step_idx, nullptr);
             break;
         default:
             throw Error(cat("Unknown message type ", static_cast<int>(msg.get_type())));

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -4,7 +4,7 @@
  * \date   Created on May 30, 2022
  * \brief  Implementation of the Executor class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -60,12 +60,6 @@ void print_to_message_queue(const std::string& text, OptionalStepIndex idx,
                             CommChannel* comm_channel)
 {
     send_message(comm_channel, Message::Type::output, text, Clock::now(), idx);
-}
-
-void log_warning_to_message_queue(const std::string& text, OptionalStepIndex idx,
-                                  CommChannel* comm_channel)
-{
-    send_message(comm_channel, Message::Type::log_warning, text, Clock::now(), idx);
 }
 
 void log_error_to_message_queue(const std::string& text, OptionalStepIndex idx,
@@ -128,7 +122,6 @@ void Executor::launch_async_execution(Sequence& sequence, Context context,
 
     // Redirect the output functions used by the parallel thread to the message queue
     context.print_function = print_to_message_queue;
-    context.log_warning_function = log_warning_to_message_queue;
     context.log_error_function = log_error_to_message_queue;
 
     future_ = std::async(std::launch::async, execute_sequence, sequence,
@@ -177,10 +170,6 @@ bool Executor::update(Sequence& sequence)
         case Message::Type::output:
             if (context_.print_function)
                 context_.print_function(msg.get_text(), step_idx, nullptr);
-            break;
-        case Message::Type::log_warning:
-            if (context_.log_warning_function)
-                context_.log_warning_function(msg.get_text(), step_idx, nullptr);
             break;
         case Message::Type::log_error:
             if (context_.log_error_function)

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -62,12 +62,6 @@ void print_to_message_queue(const std::string& text, OptionalStepIndex idx,
     send_message(comm_channel, Message::Type::output, text, Clock::now(), idx);
 }
 
-void log_info_to_message_queue(const std::string& text, OptionalStepIndex idx,
-                               CommChannel* comm_channel)
-{
-    send_message(comm_channel, Message::Type::log_info, text, Clock::now(), idx);
-}
-
 void log_warning_to_message_queue(const std::string& text, OptionalStepIndex idx,
                                   CommChannel* comm_channel)
 {
@@ -134,7 +128,6 @@ void Executor::launch_async_execution(Sequence& sequence, Context context,
 
     // Redirect the output functions used by the parallel thread to the message queue
     context.print_function = print_to_message_queue;
-    context.log_info_function = log_info_to_message_queue;
     context.log_warning_function = log_warning_to_message_queue;
     context.log_error_function = log_error_to_message_queue;
 
@@ -184,10 +177,6 @@ bool Executor::update(Sequence& sequence)
         case Message::Type::output:
             if (context_.print_function)
                 context_.print_function(msg.get_text(), step_idx, nullptr);
-            break;
-        case Message::Type::log_info:
-            if (context_.log_info_function)
-                context_.log_info_function(msg.get_text(), step_idx, nullptr);
             break;
         case Message::Type::log_warning:
             if (context_.log_warning_function)

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -367,9 +367,11 @@ Sequence::handle_execution(Context& context, CommChannel* comm,
         send_message(Message::Type::sequence_stopped_with_error, msg, Clock::now(),
                      maybe_error->get_index(), context, comm);
     }
-
-    send_message(Message::Type::sequence_stopped, cat(exec_block_name, " finished"),
-                 Clock::now(), gul14::nullopt, context, comm);
+    else
+    {
+        send_message(Message::Type::sequence_stopped, cat(exec_block_name, " finished"),
+                     Clock::now(), gul14::nullopt, context, comm);
+    }
 
     set_error(maybe_error);
     return maybe_error;

--- a/src/default_message_callback.cc
+++ b/src/default_message_callback.cc
@@ -2,9 +2,9 @@
  * \file   console.cc
  * \author Lars Froehlich
  * \date   Created on June 22, 2022
- * \brief  Implementation of several functions for console output.
+ * \brief  Implementation of the default_message_callback() function.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,28 +23,14 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <iostream>
-#include "taskolib/console.h"
+#include "taskolib/default_message_callback.h"
 
 namespace task {
 
-void print_to_stdout(const std::string& str, OptionalStepIndex, CommChannel*)
+void default_message_callback(const Message& msg)
 {
-    std::cout << str;
-}
-
-void print_info_to_stdout(const std::string& str, OptionalStepIndex, CommChannel*)
-{
-    std::cout << "INFO: " << str << "\n";
-}
-
-void print_warning_to_stdout(const std::string& str, OptionalStepIndex, CommChannel*)
-{
-    std::cout << "WARNING: " << str << "\n";
-}
-
-void print_error_to_stdout(const std::string& str, OptionalStepIndex, CommChannel*)
-{
-    std::cout << "ERROR: " << str << "\n";
+    if (msg.get_type() == Message::Type::output)
+        std::cout << msg.get_text();
 }
 
 } // namespace task

--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -4,7 +4,7 @@
  * \date   Created on June 15, 2022
  * \brief  Declaration of free functions dealing with Lua specifics.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -102,11 +102,6 @@ void install_timeout_and_termination_request_hook(sol::state& lua, TimePoint now
     std::chrono::milliseconds timeout, OptionalStepIndex step_idx,
     CommChannel* comm_channel);
 
-/// Create a print() function for Lua that wraps a print callback from the Context.
-std::function<void(sol::this_state, sol::variadic_args)>
-make_print_fct(
-    std::function<void(const std::string&, OptionalStepIndex, CommChannel*)> print_fct);
-
 // Open a safe subset of the Lua standard libraries in the given Lua state.
 //
 // This opens the math, string, table, and UTF8 libraries. The base library is also
@@ -116,8 +111,9 @@ make_print_fct(
 // \endcode
 void open_safe_library_subset(sol::state& lua);
 
-// Print a string to the (virtual) console.
-void print_fct(const std::string& text, sol::this_state sol);
+// An equivalent to Lua's print() function that stringifies and concatenates its arguments
+// and finally sends a message of type Message::Type::output with the result.
+void print_fct(sol::this_state, sol::variadic_args);
 
 // Pause execution for the specified time, observing timeouts and termination requests.
 void sleep_fct(double seconds, sol::this_state sol);

--- a/src/lua_details.h
+++ b/src/lua_details.h
@@ -59,6 +59,14 @@ void check_script_timeout(lua_State* lua_state);
 CommChannel* get_comm_channel_ptr_from_registry(lua_State* lua_state);
 
 /**
+ * Retrieve a reference to the used Context from the Lua registry.
+ *
+ * \exception Error is thrown if the appropriate registry key is not found or if it
+ *            contains a null pointer.
+ */
+const Context& get_context_from_registry(lua_State* lua_state);
+
+/**
  * Get the index of the currently executed Step from the Lua registry.
  *
  * This function has three different outcomes:
@@ -93,13 +101,13 @@ void hook_check_timeout_and_termination_request(lua_State* lua_state, lua_Debug*
  * sleep() -- wait for a given number of seconds
  * \endcode
  */
-void install_custom_commands(sol::state& lua, const Context& context);
+void install_custom_commands(sol::state& lua);
 
 // Install hooks that check for timeouts and immediate termination requests while a Lua
 // script is being executed. If one of both occurs, the script terminates with an error
 // message that contains the abort marker.
 void install_timeout_and_termination_request_hook(sol::state& lua, TimePoint now,
-    std::chrono::milliseconds timeout, OptionalStepIndex step_idx,
+    std::chrono::milliseconds timeout, OptionalStepIndex step_idx, const Context& context,
     CommChannel* comm_channel);
 
 // Open a safe subset of the Lua standard libraries in the given Lua state.

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,5 @@
 sources = files(
-    'console.cc',
+    'default_message_callback.cc',
     'deserialize_sequence.cc',
     'execute_lua_script.cc',
     'Executor.cc',

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,7 @@ sources = files(
     'Executor.cc',
     'internals.cc',
     'lua_details.cc',
+    'send_message.cc',
     'Sequence.cc',
     'SequenceManager.cc',
     'serialize_sequence.cc',

--- a/src/send_message.cc
+++ b/src/send_message.cc
@@ -1,8 +1,8 @@
 /**
- * \file   test_CommChannel.cc
+ * \file   send_message.cc
  * \author Lars Froehlich
- * \date   Created on June 8, 2022
- * \brief  Test suite for the CommChannel struct.
+ * \date   Created on January 30, 2023, based on older code
+ * \brief  Declaration of the send_message() function.
  *
  * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -22,18 +22,23 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <type_traits>
+#include "send_message.h"
 
-#include <gul14/catch.h>
+namespace task {
 
-#include "taskolib/CommChannel.h"
-
-using namespace task;
-
-TEST_CASE("CommChannel: Constructor", "[CommChannel]")
+void send_message(Message::Type type, gul14::string_view text, TimePoint timestamp,
+                  OptionalStepIndex index, const Context& context,
+                  CommChannel* comm_channel)
 {
-    static_assert(std::is_default_constructible_v<CommChannel>,
-        "CommChannel is default-constructible");
+    Message msg{ type, std::string(text), timestamp, index };
 
-    CommChannel c;
+    if (context.message_callback_function)
+        context.message_callback_function(msg);
+
+    if (comm_channel == nullptr)
+        return;
+
+    comm_channel->queue_.push(std::move(msg));
 }
+
+} // namespace task

--- a/src/send_message.h
+++ b/src/send_message.h
@@ -1,0 +1,56 @@
+/**
+ * \file   send_message.h
+ * \author Lars Froehlich
+ * \date   Created on January 30, 2023, based on older code
+ * \brief  Declaration of the send_message() function.
+ *
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef TASKOLIB_SEND_MESSAGE_H_
+#define TASKOLIB_SEND_MESSAGE_H_
+
+#include <gul14/string_view.h>
+
+#include "taskolib/CommChannel.h"
+#include "taskolib/Context.h"
+#include "taskolib/Message.h"
+#include "taskolib/StepIndex.h"
+
+namespace task {
+
+/**
+ * Call the message callback and enqueue the message in the given communication channel,
+ * if any.
+ *
+ * \param type          Message type (see Message::Type)
+ * \param text          Message text
+ * \param timestamp     Timestamp of the message
+ * \param index         An optional index (of a Step in its parent Sequence)
+ * \param context       Context with a message callback function
+ * \param comm_channel  Pointer to the communication channel. If this is null, the
+ *                      function does not attempt to push the message into any message
+ *                      queue.
+ */
+void send_message(Message::Type type, gul14::string_view text, TimePoint timestamp,
+                  OptionalStepIndex index, const Context& context,
+                  CommChannel* comm_channel = nullptr);
+
+} // namespace task
+
+#endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ test_src = files(
     'test_lua_details.cc',
     'test_main.cc',
     'test_Message.cc',
+    'test_send_message.cc',
     'test_Sequence.cc',
     'test_SequenceManager.cc',
     'test_serialize_sequence.cc',

--- a/tests/test_Message.cc
+++ b/tests/test_Message.cc
@@ -51,9 +51,9 @@ TEST_CASE("Message: Constructors", "[Message]")
     const TimePoint t0 = Clock::now();
 
     Message a;
-    Message b(Message::Type::log_error, "Test", t0, 42);
+    Message b(Message::Type::output, "Test", t0, 42);
 
-    REQUIRE(b.get_type() == Message::Type::log_error);
+    REQUIRE(b.get_type() == Message::Type::output);
     REQUIRE(b.get_text() == "Test");
     REQUIRE(b.get_timestamp() == t0);
     REQUIRE(b.get_index().has_value());
@@ -145,8 +145,8 @@ TEST_CASE("Message: set_type()", "[Message]")
     REQUIRE(&msg.set_type(Message::Type::step_started) == &msg);
     REQUIRE(msg.get_type() == Message::Type::step_started);
 
-    msg.set_type(Message::Type::log_error);
-    REQUIRE(msg.get_type() == Message::Type::log_error);
+    msg.set_type(Message::Type::output);
+    REQUIRE(msg.get_type() == Message::Type::output);
 }
 
 TEST_CASE("Message: Dump to stream", "[Message]")

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -33,7 +33,8 @@
 
 using namespace std::literals;
 using namespace task;
-using namespace Catch::Matchers;
+using Catch::Matchers::Contains;
+using Catch::Matchers::StartsWith;
 
 TEST_CASE("Step: Default constructor", "[Step]")
 {
@@ -888,10 +889,11 @@ TEST_CASE("execute(): print function", "[Step]")
     std::string output;
 
     Context context;
-    context.print_function =
-        [&output](const std::string& str, OptionalStepIndex, CommChannel*)
+    context.message_callback_function =
+        [&output](const Message& msg)
         {
-            output += str;
+            if (msg.get_type() == Message::Type::output)
+                output += msg.get_text();
         };
 
     Step step;

--- a/tests/test_send_message.cc
+++ b/tests/test_send_message.cc
@@ -1,0 +1,76 @@
+/**
+ * \file   test_send_message.cc
+ * \author Lars Froehlich
+ * \date   Created on January 30, 2023, based on older code
+ * \brief  Test suite for the send_message() function.
+ *
+ * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <thread>
+
+#include <gul14/catch.h>
+
+#include "send_message.h"
+#include "taskolib/CommChannel.h"
+#include "taskolib/Context.h"
+
+using namespace task;
+using namespace std::literals;
+
+TEST_CASE("send_message() across threads", "[CommChannel][send_message]")
+{
+    const auto timestamp = Clock::now();
+
+    CommChannel comm;
+    Context context;
+    context.message_callback_function = nullptr;
+
+    // Does nothing
+    send_message(Message::Type::output, "Test", timestamp, 0, context);
+
+    std::thread sender([=,&comm,&context]()
+        {
+            for (int i = 1; i <= 100; ++i)
+            {
+                send_message(Message::Type::step_started, "start",
+                    timestamp + std::chrono::seconds{ i }, i, context, &comm);
+                send_message(Message::Type::step_stopped, "stop",
+                    timestamp + std::chrono::seconds{ i + 1 }, i, context, &comm);
+            }
+        });
+
+    for (int i = 1; i <= 100; ++i)
+    {
+        Message msg = comm.queue_.pop();
+        REQUIRE(msg.get_type() == Message::Type::step_started);
+        REQUIRE(msg.get_text() == "start");
+        REQUIRE(msg.get_timestamp() == timestamp + std::chrono::seconds{ i });
+        REQUIRE(msg.get_index().has_value());
+        REQUIRE(*(msg.get_index()) == i);
+
+        msg = comm.queue_.pop();
+        REQUIRE(msg.get_type() == Message::Type::step_stopped);
+        REQUIRE(msg.get_text() == "stop");
+        REQUIRE(msg.get_timestamp() == timestamp + std::chrono::seconds{ i + 1 });
+        REQUIRE(msg.get_index().has_value());
+        REQUIRE(*(msg.get_index()) == i);
+    }
+
+    sender.join();
+}


### PR DESCRIPTION
This pull request changes the callbacks provided by the `Context` class: Where there used to be multiple callbacks for producing various types of output, there is now just one hook (the `message_callback_function`) that gets called whenever a message is being processed. Consequently, this hook only receives a reference to the processed message as a parameter.

`send_message()` is now the main hub for calling user hooks. Its signature changes because it needs access to the `Context` for that, with a lot of consequential downstream changes.

These modifications also have an impact on how `print()` is implemented: It basically just does the usual work of stringifying and concatenating its arguments, but then just proceeds to send a message of type `Type::output`. It is up to the user to install a hook that actually produces output in the desired format (default is "send to stdout").
    
A fair amount of renaming and reorganization of source files is associated with this change. That seemed like a reasonable thing to do to keep the structure of the code logical (for some definition of logical, that is).

This PR (of course :) ) adds unit tests for the message callback mechanism and fixes a minor bug discovered by these tests.

Closes #8.