### PR TITLE
Include some basic functions from Lua os library

### DIFF
--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -240,7 +240,7 @@ void install_timeout_and_termination_request_hook(sol::state& lua, TimePoint now
 void open_safe_library_subset(sol::state& lua)
 {
     lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::table,
-                       sol::lib::utf8);
+                       sol::lib::utf8, sol::lib::os);
 
     auto globals = lua.globals();
     globals["collectgarbage"] = sol::nil;
@@ -250,6 +250,11 @@ void open_safe_library_subset(sol::state& lua)
     globals["loadfile"] = sol::nil;
     globals["print"] = sol::nil;
     globals["require"] = sol::nil;
+    lua["os"] = lua.create_table_with(
+        "date", lua["os"]["date"],
+        "time", lua["os"]["time"],
+        "difftime", lua["os"]["difftime"]
+    );
 }
 
 void print_fct(sol::this_state sol, sol::variadic_args va)

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -214,10 +214,9 @@ void hook_abort_with_error(lua_State* lua_state, lua_Debug*)
 
 void install_custom_commands(sol::state& lua)
 {
-    auto globals = lua.globals();
-    globals["print"] = print_fct;
-    globals["sleep"] = sleep_fct;
-    globals["terminate_sequence"] =
+    lua["print"] = print_fct;
+    lua["sleep"] = sleep_fct;
+    lua["terminate_sequence"] =
         [](sol::this_state lua){ abort_script_with_error(lua, ""); };
 }
 
@@ -242,14 +241,13 @@ void open_safe_library_subset(sol::state& lua)
     lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::table,
                        sol::lib::utf8, sol::lib::os);
 
-    auto globals = lua.globals();
-    globals["collectgarbage"] = sol::nil;
-    globals["debug"] = sol::nil;
-    globals["dofile"] = sol::nil;
-    globals["load"] = sol::nil;
-    globals["loadfile"] = sol::nil;
-    globals["print"] = sol::nil;
-    globals["require"] = sol::nil;
+    lua["collectgarbage"] = sol::nil;
+    lua["debug"] = sol::nil;
+    lua["dofile"] = sol::nil;
+    lua["load"] = sol::nil;
+    lua["loadfile"] = sol::nil;
+    lua["print"] = sol::nil;
+    lua["require"] = sol::nil;
     lua["os"] = lua.create_table_with(
         "date", lua["os"]["date"],
         "time", lua["os"]["time"],

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -809,6 +809,18 @@ TEST_CASE("execute(): External commands on Lua scripts", "[Step]")
     }
 }
 
+TEST_CASE("execute(): Use some functions from os library", "[Step]")
+{
+    Context context;
+    Step step;
+    step.set_used_context_variable_names(VariableNames{ "a" });
+
+    step.set_script("a = os.date()");
+    REQUIRE_NOTHROW(step.execute(context));
+    INFO(std::get<VarString>(context.variables["a"]));
+    // To check output insert this: REQUIRE(1 == 0);
+}
+
 TEST_CASE("execute(): Lua initialization function", "[Step]")
 {
     Context context;


### PR DESCRIPTION
[why]
We do not include the os library because it contains a lot of "dangerous" functions.
Bit it also contains some very useful and harmess functions like date().

[how]
Allow a very limited subset of library os in the Lua scripts.

Fixes: #76