### PR TITLE
Github CI: Install libgit2

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -40,13 +40,13 @@ jobs:
     - name: Install Ninja
       run: |
         sudo apt install ninja-build
+
     - name: Fetch meson version for building
       uses: robinraju/release-downloader@v1.6
       with:
         repository: "mesonbuild/meson"
         tag: "0.53.2"
         fileName: "*.tar.gz"
-
     - name: Unpack meson tar ball and remove downloaded file
       run: |
         tar -xzf meson-*.tar.gz
@@ -54,6 +54,11 @@ jobs:
     - name: Create symbolic link for Meson
       run: |
         ln -s meson-*/meson.py .
+
+    - name: Install libgit2
+      run: |
+        sudo apt install libgit2-dev
+
     - name: Configure build directories
       run: |
         ./meson.py --buildtype=release build.release


### PR DESCRIPTION
With the next MR, we'll need libgit2 as a build dependency. This MR installs it in the CI setup.