### PR TITLE
Add copy and remove functionality to the SequenceManager

### DIFF
--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -131,15 +131,13 @@ public:
     std::vector<SequenceOnDisk> list_sequences() const;
 
     /**
-     * Load a sequence from the specified folder.
+     * Load a sequence from the base folder.
      *
-     * \param sequence_folder  path to the sequence folder to be loaded, relative to the
-     *                         base path
+     * \param unique_id  unique ID of the sequence to be loaded
      *
-     * \returns the deserialized sequence.
+     * \returns the loaded sequence.
      *
-     * \exception Error is thrown if the specified folder name is not valid or if it does
-     *            not contain a valid sequence.
+     * \exception Error is thrown if the sequence cannot be loaded.
      */
     Sequence load_sequence(UniqueId uid) const;
 
@@ -151,8 +149,8 @@ public:
      *
      * \param sequences  a list of sequences as obtained from list_sequences()
      */
-    Sequence load_sequence(UniqueId uid, const std::vector<SequenceOnDisk>& sequences)
-        const;
+    Sequence
+    load_sequence(UniqueId uid, const std::vector<SequenceOnDisk>& sequences) const;
 
     /**
      * Remove a sequence from the base folder.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -155,6 +155,18 @@ public:
         const;
 
     /**
+     * Remove a sequence from the base folder.
+     *
+     * The sequence to be removed is identified by its unique ID.
+     *
+     * \param unique_id  the unique ID of the sequence
+     *
+     * \exception Error is thrown if the sequence cannot be found or if the removal of
+     *            the folder fails.
+     */
+    void remove_sequence(UniqueId unique_id) const;
+
+    /**
      * Change the machine-friendly name of a sequence on disk.
      *
      * The sequence to be renamed is identified by its unique ID and the old name.
@@ -211,6 +223,13 @@ private:
      * \exception Error is thrown if no unique ID can be found.
      */
     static UniqueId create_unique_id(const std::vector<SequenceOnDisk>& sequences);
+
+    /**
+     * Find the sequence with the given unique ID in the given list of sequences.
+     * \exception Error is thrown if the sequence cannot be found.
+     */
+    static SequenceOnDisk find_sequence_on_disk(UniqueId uid,
+        const std::vector<SequenceOnDisk>& sequences);
 
     /// Generate a machine-friendly sequence name from a human-readable label.
     static SequenceName make_sequence_name_from_label(gul14::string_view label);

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -76,6 +76,23 @@ public:
     explicit SequenceManager(std::filesystem::path path);
 
     /**
+     * Create a copy of an existing sequence (from disk).
+     *
+     * This function loads an existing sequence (identified by its unique ID) from disk,
+     * assigns a new name (new_name) and a new random unique ID to it, and stores the new
+     * sequence in the base folder.
+     *
+     * \param original_uid  Unique ID of the original sequence
+     * \param new_name      Machine-friendly name of the copy
+     *
+     * \returns the copied sequence as if it had been loaded from disk.
+     *
+     * \exception Error is thrown if the original sequence cannot be found or if the new
+     *            sequence folder cannot be created.
+     */
+    Sequence copy_sequence(UniqueId original_uid, const SequenceName& new_name) const;
+
+    /**
      * Create an empty sequence on disk.
      *
      * The new sequence contains no steps and has a randomly assigned unique ID.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -169,27 +169,24 @@ public:
     /**
      * Change the machine-friendly name of a sequence on disk.
      *
-     * The sequence to be renamed is identified by its unique ID and the old name.
+     * The sequence to be renamed is identified by its unique ID.
      *
-     * \param old_name   the original machine-friendly name of the sequence
      * \param unique_id  the unique ID of the sequence
      * \param new_name   the new machine-friendly name of the sequence
      *
      * \exception Error is thrown if the sequence cannot be found or if the renaming of
      *            the folder fails.
      */
-    void rename_sequence(const SequenceName& old_name, UniqueId unique_id,
-        const SequenceName& new_name) const;
+    void rename_sequence(UniqueId unique_id, const SequenceName& new_name) const;
 
     /**
      * Change the machine-friendly name of a sequence, both in a Sequence object and on
      * disk.
      *
-     * The sequence to be renamed is identified by the unique ID and machine-friendly name
-     * of the given Sequence object. The Sequence object is updated to reflect the new
-     * name.
+     * The sequence to be renamed is identified by the unique ID of the given Sequence
+     * object. The Sequence object is updated to reflect the new name.
      *
-     * \param sequence  the sequence to be relabeled
+     * \param sequence  the sequence to be renamed
      * \param new_name  the new machine-friendly name of the sequence
      *
      * \exception Error is thrown if the sequence cannot be found or if the renaming of

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -124,7 +124,18 @@ public:
      * \exception Error is thrown if the specified folder name is not valid or if it does
      *            not contain a valid sequence.
      */
-    Sequence load_sequence(std::filesystem::path sequence_folder) const;
+    Sequence load_sequence(UniqueId uid) const;
+
+    /**
+     * \copydoc load_sequence(UniqueId)
+     *
+     * This overload allows to pass in a list of sequences to avoid having to examine the
+     * base path again:
+     *
+     * \param sequences  a list of sequences as obtained from list_sequences()
+     */
+    Sequence load_sequence(UniqueId uid, const std::vector<SequenceOnDisk>& sequences)
+        const;
 
     /**
      * Change the machine-friendly name of a sequence on disk.

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -55,7 +55,6 @@ std::string extract_filename_step(const int number, int max_digits, const Step& 
     return ss.str();
 }
 
-/// Remove Step from the file system.
 void remove_path(const std::filesystem::path& folder)
 {
     try
@@ -245,24 +244,13 @@ Sequence SequenceManager::load_sequence(UniqueId uid,
     const auto seq_on_disk = find_sequence_on_disk(uid, sequences);
 
     const auto folder = path_ / seq_on_disk.path;
+
     if (not std::filesystem::exists(folder))
         throw Error(cat("Sequence file path does not exist: ", folder.string()));
     else if (not std::filesystem::is_directory(folder))
         throw Error(cat("Sequence file path is not a directory: ", folder.string()));
 
-    SequenceInfo seq_info = get_sequence_info_from_filename(folder.filename().string());
-    if (not seq_info.unique_id)
-    {
-        throw Error(cat("Cannot load sequence from '", folder.string(),
-            "': missing unique ID"));
-    }
-    if (not seq_info.name)
-    {
-        throw Error(cat("Cannot load sequence from '", folder.string(),
-            "': missing sequence name"));
-    }
-
-    Sequence seq{ seq_info.label, *seq_info.name, *seq_info.unique_id };
+    Sequence seq{ "", seq_on_disk.name, seq_on_disk.unique_id };
 
     load_sequence_parameters(folder, seq);
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -323,14 +323,14 @@ void SequenceManager::remove_sequence(UniqueId unique_id) const
     }
 }
 
-void SequenceManager::rename_sequence(const SequenceName& old_name, UniqueId unique_id,
-    const SequenceName& new_name) const
+void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& new_name)
+    const
 {
-    const auto old_folder_name = make_sequence_filename(old_name, unique_id);
-    const auto old_path = path_ / old_folder_name;
+    const auto sequences = list_sequences();
+    const auto old_seq_on_disk = find_sequence_on_disk(unique_id, sequences);
 
-    const auto new_folder_name = make_sequence_filename(new_name, unique_id);
-    const auto new_path = path_ / new_folder_name;
+    const auto old_path = path_ / old_seq_on_disk.path;
+    const auto new_path = path_ / make_sequence_filename(new_name, unique_id);
 
     std::error_code error;
     std::filesystem::rename(old_path, new_path, error);
@@ -344,7 +344,7 @@ void SequenceManager::rename_sequence(const SequenceName& old_name, UniqueId uni
 void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& new_name)
     const
 {
-    rename_sequence(sequence.get_name(), sequence.get_unique_id(), new_name);
+    rename_sequence(sequence.get_unique_id(), new_name);
     sequence.set_name(new_name);
 }
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -102,6 +102,22 @@ SequenceManager::SequenceManager(std::filesystem::path path)
 }
 
 Sequence
+SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_name) const
+{
+    const auto sequences = list_sequences();
+    const UniqueId new_unique_id = create_unique_id(sequences);
+
+    Sequence sequence = load_sequence(original_uid, sequences);
+
+    sequence.set_unique_id(new_unique_id);
+    sequence.set_name(new_name);
+
+    store_sequence(sequence);
+
+    return sequence;
+}
+
+Sequence
 SequenceManager::create_sequence(gul14::string_view label, SequenceName name) const
 {
     const auto sequences = list_sequences();

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -290,11 +290,9 @@ TEST_CASE("SequenceManager: rename_sequence()", "[SequenceManager]")
     REQUIRE(seq1.empty());
     REQUIRE(seq1.get_name() == SequenceName{ "first_after_rename" });
 
-    manager.rename_sequence(SequenceName{ "second" }, seq2.get_unique_id(),
-        SequenceName{ "second_after_rename" });
+    manager.rename_sequence(seq2.get_unique_id(), SequenceName{ "second_after_rename" });
 
-    REQUIRE_THROWS_AS(manager.rename_sequence(SequenceName{ "inexistent" }, 0_uid,
-        SequenceName{ "Bla" }), Error);
+    REQUIRE_THROWS_AS(manager.rename_sequence(0_uid, SequenceName{ "Bla" }), Error);
 
     auto sequences = manager.list_sequences();
     std::sort(sequences.begin(), sequences.end(),

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -256,6 +256,26 @@ TEST_CASE("SequenceManager: load_sequence() - Nonexistent unique ID", "[Sequence
     REQUIRE_THROWS_AS(manager.load_sequence(UniqueId{}), Error);
 }
 
+TEST_CASE("SequenceManager: remove_sequence()", "[SequenceManager]")
+{
+    const char* dir = "unit_test_files/remove_sequence_test";
+
+    if (std::filesystem::exists(dir))
+        std::filesystem::remove_all(dir);
+
+    std::filesystem::create_directories(dir);
+    SequenceManager manager{ dir };
+
+    Sequence seq1 = manager.create_sequence("First sequence", SequenceName{ "first" });
+    Sequence seq2 = manager.create_sequence("Second sequence", SequenceName{ "second" });
+
+    manager.remove_sequence(seq1.get_unique_id());
+
+    auto sequences = manager.list_sequences();
+    REQUIRE(sequences.size() == 1);
+    REQUIRE(sequences[0].name == SequenceName{ "second" });
+}
+
 TEST_CASE("SequenceManager: rename_sequence()", "[SequenceManager]")
 {
     const char* dir = "unit_test_files/relabel_sequence_test";


### PR DESCRIPTION
This pull request adds two member functions, `SequenceManager::copy_sequence()` and `SequenceManager::remove_sequence()`, that... well, do what the names say. This is necessary because library users should not (need to) know how their sequences are stored on disk. It is also a preparatory step for introducing Git functionality.