### PR TITLE
Fix removal of non-empty sequence folders

### DIFF
--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -303,7 +303,7 @@ void SequenceManager::remove_sequence(UniqueId unique_id) const
     const auto path = path_ / seq_on_disk.path;
 
     std::error_code error;
-    std::filesystem::remove(path, error);
+    std::filesystem::remove_all(path, error);
     if (error)
     {
         throw Error(cat("Cannot remove sequence folder ", path.string(), ": ",

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -267,6 +267,9 @@ TEST_CASE("SequenceManager: remove_sequence()", "[SequenceManager]")
     SequenceManager manager{ dir };
 
     Sequence seq1 = manager.create_sequence("First sequence", SequenceName{ "first" });
+    seq1.push_back(Step{ Step::type_action });
+    manager.store_sequence(seq1);
+
     Sequence seq2 = manager.create_sequence("Second sequence", SequenceName{ "second" });
 
     manager.remove_sequence(seq1.get_unique_id());


### PR DESCRIPTION
# [why]
The lib could not remove a sequence folder that had files in it because we used remove() instead of remove_all().

# [how]
Add a unit test and use remove_all() instead of remove(). :)