### PR TITLE
Feature/82 link against libgit4cpp

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -66,7 +66,10 @@ jobs:
         ./meson.py --buildtype=debug build.asan -Db_sanitize=address
     - name: Build and run release tests
       id: buildnormal
-      run: ./meson.py test -C build.release
+      run: |
+        git config --global user.name "Github CI"
+        git config --global user.email "GithubCI@yourdomain.com"
+        ./meson.py test -C build.release
 
     - name: Save error logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -62,8 +62,8 @@ jobs:
 
     - name: Configure build directories
       run: |
-        ./meson.py --buildtype=release build.release
-        ./meson.py --buildtype=debug build.asan -Db_sanitize=address
+        ./meson.py --wrap-mode forcefallback --buildtype=release build.release
+        ./meson.py --wrap-mode forcefallback --buildtype=debug build.asan -Db_sanitize=address
     - name: Build and run release tests
       id: buildnormal
       run: |

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -55,9 +55,10 @@ jobs:
       run: |
         ln -s meson-*/meson.py .
 
-    - name: Install libgit2
+    - name: Setup dependencies
       run: |
-        sudo apt install libgit2-dev
+        sudo apt update -y -q
+        sudo apt install libgit2-dev -y -q
 
     - name: Configure build directories
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ subprojects/*/
 another/
 unit_test_files/
 index
+test.seq/
+unit_test/
+unit_test_2/
+sequences_git/

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,3 @@
 docs/html/
 build*/
 subprojects/*/
-another/
-unit_test_files/
-index
-test.seq/
-unit_test/
-unit_test_2/
-sequences_git/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Lars Froehlich <lars.froehlich@desy.de>
 Standards-Version: 4.6.0
-Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12)
+Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12), libgit4cpp-dev
 
 Package: taskolib-0-8-1
 Section: libs

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Lars Froehlich <lars.froehlich@desy.de>
 Standards-Version: 4.6.0
-Build-Depends: dev-doocs-libgul14 | libgul14-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12), libgit4cpp-dev
+Build-Depends: libgit4cpp-dev, dev-doocs-libgul14 | libgul14-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12)
 
 Package: taskolib-0-8-1
 Section: libs

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include <gul14/string_view.h>
+#include <gul14/SmallVector.h>
 #include <libgit4cpp/GitRepository.h>
 
 #include "taskolib/Sequence.h"
@@ -224,6 +225,8 @@ private:
      */
     static UniqueId create_unique_id(const std::vector<SequenceOnDisk>& sequences);
 
+    bool commit(gul14::SmallVector<gul14::string_view, 2> dirs, gul14::string_view message);
+
     /**
      * Stage all changes to files in the given directory for the next git commit.
      *
@@ -237,7 +240,7 @@ private:
      * \returns a partial commit message containing information about the staged changes.
      *          The returned string starts with a linebreak.
      */
-    std::string stage_files_in_directory(const std::string& directory);
+    std::string stage_files_in_directory(gul14::string_view directory);
 
     /**
      * Stage files matching the specified glob for the next git commit.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -278,3 +278,5 @@ private:
 } // namespace task
 
 #endif
+
+// vi:ts=4:sw=4:sts=4:et

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -206,8 +206,9 @@ public:
      * This function use git.
      *
      * \param sequence  the sequence to be stored
+     * \param intent    reason for storing the sequence, "change" is default
      */
-    void store_sequence(const Sequence& sequence);
+    void store_sequence(const Sequence& sequence, gul14::string_view intent = "change");
 
 private:
     /// Base path to the sequences.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -225,14 +225,17 @@ private:
     static UniqueId create_unique_id(const std::vector<SequenceOnDisk>& sequences);
 
     /**
-     * Stage all files git can find in a repository.
+     * Stage files matching the specified glob for the next git commit.
      *
-     * A file-glob can be specified to find only the files that are wanted.
+     * This function is similar to "git add", but it can also stage files for removal like
+     * "git rm".
      *
-     * \param glob  Main pathname specification which files to add as glob.
-     *              If it is empty ("") all files in the repo are considered.
-     * \return      Commit message starting with a linebreak.
-    */
+     * \param glob  A git glob specifying which files to stage. If it is empty, all files
+     *              in the repository are considered. Examples: "", "foo/*", "*.txt",
+     *              "*.bak[0-9]"
+     * \returns a partial commit message containing information about the staged changes.
+     *          The returned string starts with a linebreak.
+     */
     std::string stage_files_in_directory(const std::string& glob);
 
     /**

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -245,10 +245,12 @@ private:
     static SequenceName make_sequence_name_from_label(gul14::string_view label);
 
     /**
-     * private function to store a sequence without commit in git.
-     * \param sequence sequence object
+     * Actually write a sequence to disk (without commit in git)
+     *
+     * \param sequence  Sequence object to save
+     * \returns         Folder of the sequence on disk (relative to path_)
     */
-    void store_sequence_impl(const Sequence& sequence) const;
+    std::string write_sequence_to_disk(const Sequence& sequence);
 };
 
 /**
@@ -258,7 +260,7 @@ private:
  * Afterwards the string is a literal when used in globbing contexts.
  *
  * \param path   String that contains a literal path (shall not glob)
- * \return       String that can be used for the path in globbing contexts
+ * \returns      String that can be used for the path in globbing contexts
  */
 std::string escape_glob(const std::string& path);
 

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -206,9 +206,8 @@ public:
      * This function use git.
      *
      * \param sequence  the sequence to be stored
-     * \param intent    reason for storing the sequence, "change" is default
      */
-    void store_sequence(const Sequence& sequence, gul14::string_view intent = "change");
+    void store_sequence(const Sequence& sequence);
 
 private:
     /// Base path to the sequences.
@@ -227,24 +226,14 @@ private:
 
     /**
      * Stage all files git can find in a repository.
-     * parameter dir and filetype are used as filter.
-     * To stage all, use
-     *     - dir_name = ""
-     *     - filetype = ""
-     * \param dir relative path to sequence from path_ as base
-     * To restrict staging to one sequence, set dir to the sequence directory
-     * \param filetype define which file status group shall be staged
-     * filetype values:
-     *     - "" = all types allowed
-     *     - "new file"
-     *     - "modified"
-     *     - "deleted"
-     *     - "renamed"
-     *     - "typechange"
-     *     - "untracked"
-     * \return commit message starting with a linebreak
+     * Two globs can be specified to find only the files that are wanted.
+     *
+     * \param glob1  Main pathname specification which files to add as glob.
+     *               If it is "" all files in the repo are considered.
+     * \param glob2  Secondary pathname specification. If it is "" it is ignored.
+     * \return       Commit message starting with a linebreak.
     */
-    std::string stage_files_in_directory(std::filesystem::path dir_name, const std::string& filetype);
+    std::string stage_files_in_directory(const std::string& glob1, const std::string& glob2 = "");
 
     /**
      * Find the sequence with the given unique ID in the given list of sequences.
@@ -262,6 +251,17 @@ private:
     */
     void store_sequence_impl(const Sequence& sequence) const;
 };
+
+/**
+ * Escape all glob characters from a literal path
+ *
+ * We escape all globbing characters *, ?, \, [, ].
+ * Afterwards the string is a literal when used in globbing contexts.
+ *
+ * \param path   String that contains a literal path (shall not glob)
+ * \return       String that can be used for the path in globbing contexts
+ */
+std::string escape_glob(const std::string& path);
 
 } // namespace task
 

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -227,10 +227,13 @@ private:
 
     /**
      * Stage all files git can find in a repository.
-     * parameter dir and fileytpe are used as filter.
+     * parameter dir and filetype are used as filter.
      * To stage all, use
      *     - dir_name = ""
      *     - filetype = ""
+     * \param dir relative path to sequence from path_ as base
+     * To restrict staging to one sequence, set dir to the sequence directory
+     * \param filetype define which file status group shall be staged
      * filetype values:
      *     - "" = all types allowed
      *     - "new file"
@@ -239,8 +242,6 @@ private:
      *     - "renamed"
      *     - "typechange"
      *     - "untracked"
-     * \param dir relative path to sequence from path_ as base
-     * \param filetype define which file status group shall be staged
      * \return commit message starting with a linebreak
     */
     std::string stage_files_in_directory(std::filesystem::path dir_name, const std::string& filetype);

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -106,8 +106,7 @@ public:
      *
      * \exception Error is thrown if the sequence folder cannot be created.
      */
-    Sequence create_sequence(gul14::string_view label = "",
-        SequenceName name = SequenceName{}) const;
+    Sequence create_sequence(gul14::string_view label = "", SequenceName name = SequenceName{});
 
     /**
      * Return the base path of the serialized sequences.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -213,7 +213,7 @@ private:
     /// Base path to the sequences.
     std::filesystem::path path_;
 
-    /// Git Repository object
+    /// Git repository in path_ that holds the sequences
     git::GitRepository git_repo_;
 
     /**
@@ -226,6 +226,7 @@ private:
 
     /**
      * Stage all files git can find in a repository.
+     *
      * A file-glob can be specified to find only the files that are wanted.
      *
      * \param glob  Main pathname specification which files to add as glob.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -107,7 +107,7 @@ public:
      * \exception Error is thrown if the sequence folder cannot be created.
      */
     Sequence create_sequence(gul14::string_view label = "",
-        SequenceName name = SequenceName{});
+        SequenceName name = SequenceName{}) const;
 
     /**
      * Return the base path of the serialized sequences.
@@ -214,7 +214,7 @@ private:
     /// Base path to the sequences.
     std::filesystem::path path_;
 
-    /// Git Repsoitory object
+    /// Git Repository object
     git::GitRepository git_repo_;
 
     /**
@@ -228,11 +228,19 @@ private:
     /**
      * Stage all files git can find in a repository.
      * parameter dir and fileytpe are used as filter.
-     * To stage all, use dir_name = "" and filetype = ""
-     * filetype values: {"", "new file", "modified", "deleted",
-     * "renamed", "typechange", "untracked"}
+     * To stage all, use
+     *     - dir_name = ""
+     *     - filetype = ""
+     * filetype values:
+     *     - "" = all types allowed
+     *     - "new file"
+     *     - "modified"
+     *     - "deleted"
+     *     - "renamed"
+     *     - "typechange"
+     *     - "untracked"
      * \param dir relative path to sequence from path_ as base
-     * \param filetype 
+     * \param filetype define which file status group shall be staged
      * \return commit message starting with a linebreak
     */
     std::string stage_files_in_directory(std::filesystem::path dir_name, const std::string& filetype);

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -225,18 +225,33 @@ private:
     static UniqueId create_unique_id(const std::vector<SequenceOnDisk>& sequences);
 
     /**
+     * Stage all changes to files in the given directory for the next git commit.
+     *
+     * This function is similar to "git add", but it can also stage files for removal like
+     * "git rm". It recursively stages all changes to files in the given directory and in
+     * its subdirectories.
+     *
+     * \param directory  Directory whose contents should be staged. Glob/wildcard
+     *                   characters like '*' or '?' are considered a literal part of the
+     *                   directory name and escaped automatically.
+     * \returns a partial commit message containing information about the staged changes.
+     *          The returned string starts with a linebreak.
+     */
+    std::string stage_files_in_directory(const std::string& directory);
+
+    /**
      * Stage files matching the specified glob for the next git commit.
      *
      * This function is similar to "git add", but it can also stage files for removal like
      * "git rm".
      *
      * \param glob  A git glob specifying which files to stage. If it is empty, all files
-     *              in the repository are considered. Examples: "", "foo/*", "*.txt",
-     *              "*.bak[0-9]"
+     *              in the repository are considered. Examples: "", "*.txt",
+     *              "foo/backup_[0-9].dat"
      * \returns a partial commit message containing information about the staged changes.
      *          The returned string starts with a linebreak.
      */
-    std::string stage_files_in_directory(const std::string& glob);
+    std::string stage_files(const std::string& glob);
 
     /**
      * Find the sequence with the given unique ID in the given list of sequences.
@@ -256,17 +271,6 @@ private:
     */
     std::string write_sequence_to_disk(const Sequence& sequence);
 };
-
-/**
- * Escape all glob characters from a literal path
- *
- * We escape all globbing characters *, ?, \, [, ].
- * Afterwards the string is a literal when used in globbing contexts.
- *
- * \param path   String that contains a literal path (shall not glob)
- * \returns      String that can be used for the path in globbing contexts
- */
-std::string escape_glob(const std::string& path);
 
 } // namespace task
 

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -263,7 +263,7 @@ private:
      *
      */
     template <typename T>
-    bool perform_commit(gul14::SmallVector<gul14::string_view, 2> dirs, std::string message, T action)
+    bool perform_commit(gul14::SmallVector<std::string, 2> dirs, std::string message, T action)
     {
         auto commit_body = std::string{ };
         try {
@@ -292,8 +292,6 @@ private:
         return true;
     }
 
-    //bool commit(gul14::SmallVector<gul14::string_view, 2> dirs, gul14::string_view message);
-
     /**
      * Stage all changes to files in the given directory for the next git commit.
      *
@@ -307,7 +305,7 @@ private:
      * \returns a partial commit message containing information about the staged changes.
      *          The returned string starts with a linebreak.
      */
-    std::string stage_files_in_directory(gul14::string_view directory);
+    std::string stage_files_in_directory(const std::string& directory);
 
     /**
      * Stage files matching the specified glob for the next git commit.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -263,7 +263,7 @@ private:
      *
      */
     template <typename T>
-    bool perform_commit(gul14::SmallVector<std::string, 2> dirs, std::string message, T action)
+    bool perform_commit(std::string message, T action, std::string extra_dir = "")
     {
         auto commit_body = std::string{ };
         try {
@@ -271,13 +271,12 @@ private:
             if constexpr (std::is_same<decltype(action()), void>::value)
                 action();
             else {
-                auto add_path = action();
-                message += add_path;
-                dirs.push_back(add_path);
+                auto path = action();
+                commit_body = stage_files_in_directory(path);
+                message += path;
             }
-            for (auto& dir : dirs) {
-                commit_body = stage_files_in_directory(dir);
-            }
+            if (not extra_dir.empty())
+                commit_body = stage_files_in_directory(extra_dir);
             if (commit_body.empty())
                 return false;
             git_repo_.commit(gul14::cat(message, "\n", commit_body));

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -226,14 +226,13 @@ private:
 
     /**
      * Stage all files git can find in a repository.
-     * Two globs can be specified to find only the files that are wanted.
+     * A file-glob can be specified to find only the files that are wanted.
      *
-     * \param glob1  Main pathname specification which files to add as glob.
-     *               If it is "" all files in the repo are considered.
-     * \param glob2  Secondary pathname specification. If it is "" it is ignored.
-     * \return       Commit message starting with a linebreak.
+     * \param glob  Main pathname specification which files to add as glob.
+     *              If it is empty ("") all files in the repo are considered.
+     * \return      Commit message starting with a linebreak.
     */
-    std::string stage_files_in_directory(const std::string& glob1, const std::string& glob2 = "");
+    std::string stage_files_in_directory(const std::string& glob);
 
     /**
      * Find the sequence with the given unique ID in the given list of sequences.

--- a/include/taskolib/Timeout.h
+++ b/include/taskolib/Timeout.h
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <cmath>
 #include <limits>
+#include <ostream>
 
 #include "taskolib/exceptions.h"
 
@@ -185,6 +186,14 @@ private:
 
     Duration timeout_{ infinite_duration };
 };
+
+inline std::ostream& operator<<(std::ostream& stream, const Timeout& timeout) {
+    if (!isfinite(timeout))
+        stream << "infinite";
+    else
+        stream << static_cast<std::chrono::milliseconds>(timeout).count();
+    return stream;
+}
 
 } // namespace task
 

--- a/include/taskolib/format.h
+++ b/include/taskolib/format.h
@@ -28,18 +28,11 @@
 #include <fmt/format.h>
 #include <sstream>
 
-#include "taskolib/time_types.h"
 #include "taskolib/Message.h"
+#include "taskolib/time_types.h"
+#include "taskolib/Timeout.h"
 
-template<> struct fmt::formatter<task::TimePoint> {
-    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
-        return ctx.begin();
-    }
-    template <typename FormatContext>
-    auto format(task::TimePoint const& val, FormatContext& ctx) -> decltype(ctx.out()) {
-        return format_to(ctx.out(), "{}", task::to_string(val));
-    }
-};
+using namespace std::literals;
 
 template<> struct fmt::formatter<task::Message> {
     constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
@@ -50,6 +43,28 @@ template<> struct fmt::formatter<task::Message> {
         std::stringstream ss{ };
         ss << val;
         return format_to(ctx.out(), "{}", ss.str());
+    }
+};
+
+template<> struct fmt::formatter<task::Timeout> {
+    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(task::Timeout const& val, FormatContext& ctx) -> decltype(ctx.out()) {
+        std::stringstream ss{ };
+        ss << val;
+        return format_to(ctx.out(), "{}", ss.str());
+    }
+};
+
+template<> struct fmt::formatter<task::TimePoint> {
+    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+        return ctx.begin();
+    }
+    template <typename FormatContext>
+    auto format(task::TimePoint const& val, FormatContext& ctx) -> decltype(ctx.out()) {
+        return format_to(ctx.out(), "{}", task::to_string(val));
     }
 };
 

--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ deps = [
     dependency('threads'),
     gul_dep.partial_dependency(compile_args : true, includes : true),
     lua_dep,
-    dependency('libgit4cpp'),
+    dependency('libgit4cpp', fallback : ['libgit4cpp', 'libgit4cpp_dep']),
 
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,8 @@ deps = [
     dependency('threads'),
     gul_dep.partial_dependency(compile_args : true, includes : true),
     lua_dep,
+    dependency('libgit4cpp'),
+
 ]
 
 lib = both_libraries(meson.project_name(),
@@ -100,6 +102,7 @@ taskolib_dep = declare_dependency(
     include_directories : inc,
     link_with : lib,
     dependencies : [ deps, gul_dep, ],
+    
 )
 
 subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,12 @@ libno_full = '.'.join(libno_parts)
 ## https://stackoverflow.com/questions/52516165/cannot-use-the-c-stdfilesystem-library-with-meson-build
 add_project_link_arguments(['-lstdc++fs'], language : 'cpp')
 
+## libgit2 has obviously a change in the globbing
+local_cpp_args = []
+if dependency('libgit2').version().version_compare('<1')
+    message('Ancient libgit2 version detected')
+    local_cpp_args += [ '-DANCIENT_LIBGIT2' ]
+endif
 
 ## Build library
 subdir('include')
@@ -75,6 +81,7 @@ deps = [
 
 lib = both_libraries(meson.project_name(),
     sources,
+    cpp_args : local_cpp_args,
     dependencies : deps,
     soversion : libno_full,
     darwin_versions : libno,

--- a/meson.build
+++ b/meson.build
@@ -56,10 +56,10 @@ libno_full = '.'.join(libno_parts)
 add_project_link_arguments(['-lstdc++fs'], language : 'cpp')
 
 ## libgit2 has obviously a change in the globbing
-local_cpp_args = []
+local_compiler_args = []
 if dependency('libgit2').version().version_compare('<1')
     message('Ancient libgit2 version detected')
-    local_cpp_args += [ '-DANCIENT_LIBGIT2' ]
+    local_compiler_args += [ '-DANCIENT_LIBGIT2' ]
 endif
 
 ## Build library
@@ -76,21 +76,19 @@ deps = [
     gul_dep.partial_dependency(compile_args : true, includes : true),
     lua_dep,
     dependency('libgit4cpp', fallback : ['libgit4cpp', 'libgit4cpp_dep']),
-
 ]
 
 lib = both_libraries(meson.project_name(),
     sources,
-    cpp_args : local_cpp_args,
-    dependencies : deps,
+    dependencies : deps + [ declare_dependency(compile_args : local_compiler_args) ],
     soversion : libno_full,
     darwin_versions : libno,
     include_directories : inc,
     build_rpath : meson.current_build_dir(),
     install_rpath : get_option('prefix') / get_option('libdir'),
     #gnu_symbol_visibility : 'hidden',
-    install : true)
-
+    install : true,
+)
 
 ## pkg-config
 
@@ -109,7 +107,6 @@ taskolib_dep = declare_dependency(
     include_directories : inc,
     link_with : lib,
     dependencies : [ deps, gul_dep, ],
-    
 )
 
 subdir('tests')

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -337,7 +337,8 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
     }
 
     // commit to local repository
-    auto commit_msg = stage_files_in_directory(escape_glob(old_seq_on_disk.path), escape_glob(new_disk_name));
+    stage_files_in_directory(escape_glob(old_seq_on_disk.path)); // result discarded, the next call will pick it up
+    auto commit_msg = stage_files_in_directory(escape_glob(new_disk_name));
     if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Rename ", old_seq_on_disk.path.string(), " to ", new_disk_name, "\n", commit_msg));
 }
@@ -380,14 +381,9 @@ void SequenceManager::store_sequence_impl(const Sequence& seq) const
 }
 
 
-std::string SequenceManager::stage_files_in_directory(const std::string& glob1, const std::string& glob2)
+std::string SequenceManager::stage_files_in_directory(const std::string& glob)
 {
-    git_repo_.add(glob1);
-    git_repo_.update(glob1);
-    if (not glob2.empty()) {
-        git_repo_.add(glob2);
-        git_repo_.update(glob2);
-    }
+    git_repo_.add(glob);
 
     auto git_msg = ""s;
     for(const auto& elm: git_repo_.status()) {

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -402,30 +402,30 @@ std::string SequenceManager::stage_files_in_directory(std::filesystem::path dir_
         {
             if (elm.changes == "new file" and (filetype == elm.changes or filetype == ""))
             {
-                git_msg += gul14::cat("\n", "- create '",elm.path_name, "'");
+                git_msg += gul14::cat("\n- create '", elm.path_name, "'");
             }
             else if (elm.changes == "modified" and (filetype == elm.changes or filetype == ""))
             {
-                git_msg += gul14::cat("\n", "- modify '",elm.path_name, "'");
+                git_msg += gul14::cat("\n- modify '", elm.path_name, "'");
             }
             else if (elm.changes == "deleted" and (filetype == elm.changes or filetype == ""))
             {
-                git_msg += gul14::cat("\n", "- delete '",elm.path_name, "'");
+                git_msg += gul14::cat("\n- delete '", elm.path_name, "'");
                 git_repo_.remove_files({elm.path_name});
                 continue;
             }
             else if (elm.changes == "renamed" and (filetype == elm.changes or filetype == ""))
             {
-                git_msg += gul14::cat("\n", "- rename '",elm.path_name, "'");
+                git_msg += gul14::cat("\n- rename '", elm.path_name, "'");
             }
             else if (elm.changes == "typechange" and (filetype == elm.changes or filetype == ""))
             {
-                git_msg += gul14::cat("\n", "- '",elm.path_name, "' has its type change");
+                git_msg += gul14::cat("\n- '", elm.path_name, "' has its type change");
             }
             else if (elm.changes == "untracked" and (filetype == elm.changes or filetype == ""))
             {
                 const auto elmpath = (std::filesystem::path) elm.path_name;
-                git_msg += gul14::cat("\n", "- Add ",elmpath.filename().string(), " from new sequence '", dir_name.string(), "'");
+                git_msg += gul14::cat("\n- Add ", elmpath.filename().string(), " from new sequence '", dir_name.string(), "'");
             }
             else continue;
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -408,8 +408,6 @@ std::string SequenceManager::stage_files_in_directory(std::filesystem::path dir_
             {
                 git_msg += gul14::cat("\n", "- modify '",elm.path_name, "'");
             }
-            //TODO: file number is changing. Figure out which file is deleted
-            //INFO: Maybe git figures it out on its own and tag it with "renamed"
             else if (elm.changes == "deleted" and (filetype == elm.changes or filetype == ""))
             {
                 git_msg += gul14::cat("\n", "- delete '",elm.path_name, "'");

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -418,3 +418,5 @@ std::string SequenceManager::stage_files_in_directory(gul14::string_view directo
 }
 
 } // namespace task
+
+// vi:ts=4:sw=4:sts=4:et

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -107,7 +107,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
     // commit to local repository
     const auto new_folder_name = make_sequence_filename(new_name, new_unique_id);
     const auto commit_msg = stage_files_in_directory(escape_glob(new_folder_name) + "/");
-    if (commit_msg != "")
+    if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Copy sequence ", old_name.string(), " to ", new_folder_name, "\n", commit_msg));
 
     return sequence;
@@ -133,7 +133,7 @@ SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
     auto seq = Sequence{ label, name, unique_id };
     store_sequence_impl(seq);
     const auto commit_msg = stage_files_in_directory(escape_glob(new_folder_name) + "/");
-    if (commit_msg != "")
+    if (not commit_msg/empty())
         git_repo_.commit(gul14::cat("Create sequence ", new_folder_name, "\n", commit_msg));
 
     return seq;
@@ -315,7 +315,7 @@ void SequenceManager::remove_sequence(UniqueId unique_id)
 
     // commit to local repository
     const auto commit_msg = stage_files_in_directory(escape_glob(seq_on_disk.path) + "/");
-    if (commit_msg != "")
+    if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Remove sequence ", seq_on_disk.path.string(), "\n", commit_msg));
 
 }
@@ -338,7 +338,7 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
 
     // commit to local repository
     auto commit_msg = stage_files_in_directory(escape_glob(old_seq_on_disk.path) + "/", escape_glob(new_disk_name) + "/");
-    if (commit_msg != "")
+    if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Rename ", old_seq_on_disk.path.string(), " to ", new_disk_name, "\n", commit_msg));
 }
 
@@ -357,7 +357,7 @@ void SequenceManager::store_sequence(const Sequence& seq)
     const auto commit_msg = stage_files_in_directory(escape_glob(dir_name) + "/");
 
     // commit to local repository
-    if (commit_msg != "")
+    if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Modify sequence ", dir_name, "\n", commit_msg));
 }
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -100,7 +100,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
 
     const auto old_name = find_sequence_on_disk(original_uid, sequences).path;
 
-    perform_commit({ }, gul14::cat("Copy sequence ", old_name.string(), " to "), [&]()
+    perform_commit(gul14::cat("Copy sequence ", old_name.string(), " to "), [&]()
         {
             return write_sequence_to_disk(seq);
         });
@@ -115,7 +115,7 @@ SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
     const UniqueId unique_id = create_unique_id(sequences);
     auto seq = Sequence{ label, name, unique_id };
 
-    perform_commit({ }, "Create sequence ", [&]()
+    perform_commit("Create sequence ", [&]()
         {
             return write_sequence_to_disk(seq);
         });
@@ -290,7 +290,7 @@ void SequenceManager::remove_sequence(UniqueId unique_id)
     const auto seq_on_disk = find_sequence_on_disk(unique_id, sequences);
     const auto path = path_ / seq_on_disk.path;
 
-    perform_commit({ seq_on_disk.path.string() }, gul14::cat("Remove sequence ", seq_on_disk.path.string()), [&]()
+    perform_commit("Remove sequence ", [&]()
         {
             std::error_code error;
             std::filesystem::remove_all(path, error);
@@ -299,6 +299,7 @@ void SequenceManager::remove_sequence(UniqueId unique_id)
                 throw Error(cat("Cannot remove sequence folder ", path.string(), ": ",
                     error.message()));
             }
+            return seq_on_disk.path;
         });
 }
 
@@ -311,7 +312,7 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
     const auto new_path = path_ / new_disk_name;
 
     auto old_disk_name = old_seq_on_disk.path.string();
-    perform_commit({ old_disk_name, new_disk_name }, gul14::cat("Rename ", old_disk_name, " to ", new_disk_name), [&]()
+    perform_commit(gul14::cat("Rename ", old_disk_name, " to "), [&]()
         {
             std::error_code error;
             std::filesystem::rename(old_path, new_path, error);
@@ -320,7 +321,9 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
                 throw Error(gul14::cat("Cannot rename folder ", old_path.string(),
                     " to ", new_path.string(), ": ", error.message()));
             }
-        });
+            return new_disk_name;
+        },
+        old_disk_name);
 }
 
 void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& new_name)
@@ -331,7 +334,7 @@ void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& ne
 
 void SequenceManager::store_sequence(const Sequence& seq)
 {
-    perform_commit({ }, "Modify sequence ", [&]()
+    perform_commit("Modify sequence ", [&]()
         {
             return write_sequence_to_disk(seq);
         });

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -110,7 +110,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
 }
 
 Sequence
-SequenceManager::create_sequence(gul14::string_view label, SequenceName name) const
+SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
 {
     const auto sequences = list_sequences();
     const UniqueId unique_id = create_unique_id(sequences);
@@ -376,7 +376,7 @@ std::string SequenceManager::stage_files_in_directory(std::filesystem::path dir_
     auto stats = git_repo_.status();
     for(const auto& elm: stats)
     {
-        
+
         // filter for changes in sequence
         if (gul14::starts_with(elm.path_name, dir_name.string()))
         {

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -32,8 +32,8 @@
 #include "serialize_sequence.h"
 #include "taskolib/SequenceManager.h"
 
-#include <libgit4cpp/GitRepository.h>
 #include <libgit4cpp/Error.h>
+#include <libgit4cpp/GitRepository.h>
 
 using namespace std::literals::string_literals;
 using gul14::cat;

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -374,7 +374,7 @@ std::string SequenceManager::stage_files(const std::string& glob)
 
 namespace {
 
-std::string escape_glob(gul14::string_view path)
+std::string escape_glob(const std::string& path)
 {
     auto escaped = ""s;
     escaped.reserve(path.length());
@@ -409,7 +409,7 @@ std::string escape_glob(gul14::string_view path)
 
 } // anonymous namespace
 
-std::string SequenceManager::stage_files_in_directory(gul14::string_view directory)
+std::string SequenceManager::stage_files_in_directory(const std::string& directory)
 {
     return stage_files(escape_glob(directory));
 }

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -126,7 +126,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
 }
 
 Sequence
-SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
+SequenceManager::create_sequence(gul14::string_view label, SequenceName name) const
 {
     const auto sequences = list_sequences();
     const UniqueId unique_id = create_unique_id(sequences);
@@ -307,7 +307,6 @@ SequenceName SequenceManager::make_sequence_name_from_label(gul14::string_view l
 
 void SequenceManager::remove_sequence(UniqueId unique_id)
 {
-
     const auto sequences = list_sequences();
     const auto seq_on_disk = find_sequence_on_disk(unique_id, sequences);
     const auto path = path_ / seq_on_disk.path;
@@ -331,8 +330,6 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
 {
     const auto sequences = list_sequences();
     const auto old_seq_on_disk = find_sequence_on_disk(unique_id, sequences);
-
-
     const auto old_path = path_ / old_seq_on_disk.path;
     const auto new_path = path_ / make_sequence_filename(new_name, unique_id);
 
@@ -394,7 +391,6 @@ void SequenceManager::store_sequence_impl(const Sequence& seq) const
 
 std::string SequenceManager::stage_files_in_directory(std::filesystem::path dir_name, const std::string& filetype)
 {
-
     // detect what has changed in the sequence
     std::string git_msg{""};
     auto stats = git_repo_.status();

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -101,9 +101,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
     const auto old_name = find_sequence_on_disk(original_uid, sequences).path;
 
     const auto new_folder_name = write_sequence_to_disk(seq);
-    const auto commit_msg = stage_files_in_directory(new_folder_name);
-    if (not commit_msg.empty())
-        git_repo_.commit(gul14::cat("Copy sequence ", old_name.string(), " to ", new_folder_name, "\n", commit_msg));
+    commit({ new_folder_name }, gul14::cat("Copy sequence ", old_name.string(), " to ", new_folder_name));
 
     return seq;
 }
@@ -116,9 +114,7 @@ SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
     auto seq = Sequence{ label, name, unique_id };
 
     const auto new_folder_name = write_sequence_to_disk(seq);
-    const auto commit_msg = stage_files_in_directory(new_folder_name);
-    if (not commit_msg.empty())
-        git_repo_.commit(gul14::cat("Create sequence ", new_folder_name, "\n", commit_msg));
+    commit({ new_folder_name }, gul14::cat("Create sequence ", new_folder_name));
 
     return seq;
 }
@@ -298,10 +294,7 @@ void SequenceManager::remove_sequence(UniqueId unique_id)
             error.message()));
     }
 
-    const auto commit_msg = stage_files_in_directory(seq_on_disk.path);
-    if (not commit_msg.empty())
-        git_repo_.commit(gul14::cat("Remove sequence ", seq_on_disk.path.string(), "\n", commit_msg));
-
+    commit({ seq_on_disk.path.string() }, gul14::cat("Remove sequence ", seq_on_disk.path.string()));
 }
 
 void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& new_name)
@@ -320,10 +313,8 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
             " to ", new_path.string(), ": ", error.message()));
     }
 
-    stage_files_in_directory(old_seq_on_disk.path); // result discarded, the next call will pick it up
-    auto commit_msg = stage_files_in_directory(new_disk_name);
-    if (not commit_msg.empty())
-        git_repo_.commit(gul14::cat("Rename ", old_seq_on_disk.path.string(), " to ", new_disk_name, "\n", commit_msg));
+    auto old_disk_name = old_seq_on_disk.path.string();
+    commit({ old_disk_name, new_disk_name }, gul14::cat("Rename ", old_disk_name, " to ", new_disk_name));
 }
 
 void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& new_name)
@@ -335,9 +326,7 @@ void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& ne
 void SequenceManager::store_sequence(const Sequence& seq)
 {
     const auto dir_name = write_sequence_to_disk(seq);
-    const auto commit_msg = stage_files_in_directory(dir_name);
-    if (not commit_msg.empty())
-        git_repo_.commit(gul14::cat("Modify sequence ", dir_name, "\n", commit_msg));
+    commit({ dir_name }, gul14::cat("Modify sequence ", dir_name));
 }
 
 std::string SequenceManager::write_sequence_to_disk(const Sequence& seq)
@@ -361,6 +350,17 @@ std::string SequenceManager::write_sequence_to_disk(const Sequence& seq)
     return folder;
 }
 
+bool SequenceManager::commit(gul14::SmallVector<gul14::string_view, 2> dirs, gul14::string_view message) {
+    auto commit_body = ""s;
+    for (auto& dir : dirs) {
+        commit_body = stage_files_in_directory(dir);
+    }
+    if (commit_body.empty())
+        return false;
+    git_repo_.commit(gul14::cat(message, "\n", commit_body));
+    return true;
+}
+
 std::string SequenceManager::stage_files(const std::string& glob)
 {
     git_repo_.add(glob);
@@ -377,7 +377,7 @@ std::string SequenceManager::stage_files(const std::string& glob)
 
 namespace {
 
-std::string escape_glob(const std::string& path)
+std::string escape_glob(gul14::string_view path)
 {
     auto escaped = ""s;
     escaped.reserve(path.length());
@@ -412,7 +412,7 @@ std::string escape_glob(const std::string& path)
 
 } // anonymous namespace
 
-std::string SequenceManager::stage_files_in_directory(const std::string& directory)
+std::string SequenceManager::stage_files_in_directory(gul14::string_view directory)
 {
     return stage_files(escape_glob(directory));
 }

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -106,7 +106,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
 
     // commit to local repository
     const auto new_folder_name = make_sequence_filename(new_name, new_unique_id);
-    const auto commit_msg = stage_files_in_directory(escape_glob(new_folder_name) + "/");
+    const auto commit_msg = stage_files_in_directory(escape_glob(new_folder_name));
     if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Copy sequence ", old_name.string(), " to ", new_folder_name, "\n", commit_msg));
 
@@ -132,8 +132,8 @@ SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
 
     auto seq = Sequence{ label, name, unique_id };
     store_sequence_impl(seq);
-    const auto commit_msg = stage_files_in_directory(escape_glob(new_folder_name) + "/");
-    if (not commit_msg/empty())
+    const auto commit_msg = stage_files_in_directory(escape_glob(new_folder_name));
+    if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Create sequence ", new_folder_name, "\n", commit_msg));
 
     return seq;
@@ -314,7 +314,7 @@ void SequenceManager::remove_sequence(UniqueId unique_id)
     }
 
     // commit to local repository
-    const auto commit_msg = stage_files_in_directory(escape_glob(seq_on_disk.path) + "/");
+    const auto commit_msg = stage_files_in_directory(escape_glob(seq_on_disk.path));
     if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Remove sequence ", seq_on_disk.path.string(), "\n", commit_msg));
 
@@ -337,7 +337,7 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
     }
 
     // commit to local repository
-    auto commit_msg = stage_files_in_directory(escape_glob(old_seq_on_disk.path) + "/", escape_glob(new_disk_name) + "/");
+    auto commit_msg = stage_files_in_directory(escape_glob(old_seq_on_disk.path), escape_glob(new_disk_name));
     if (not commit_msg.empty())
         git_repo_.commit(gul14::cat("Rename ", old_seq_on_disk.path.string(), " to ", new_disk_name, "\n", commit_msg));
 }
@@ -354,7 +354,7 @@ void SequenceManager::store_sequence(const Sequence& seq)
 
     // detect what has changed in the sequence
     const auto dir_name = make_sequence_filename(seq.get_name(), seq.get_unique_id());
-    const auto commit_msg = stage_files_in_directory(escape_glob(dir_name) + "/");
+    const auto commit_msg = stage_files_in_directory(escape_glob(dir_name));
 
     // commit to local repository
     if (not commit_msg.empty())
@@ -426,6 +426,9 @@ std::string escape_glob(const std::string& path)
             break;
         }
     }
+#   ifndef ANCIENT_LIBGIT2
+        escaped += "/*";
+#   endif
     return escaped;
 }
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -64,12 +64,12 @@ void store_sequence_parameters(const std::filesystem::path& lua_file, const Sequ
     std::error_code error;
     std::filesystem::remove(lua_file, error);
     if (error)
-        throw Error(cat("I/O error: ", error.message()));
+        throw Error{ cat("I/O error: ", error.message()) };
 
     std::ofstream stream(lua_file);
 
     if (not stream.is_open())
-        throw Error(gul14::cat("I/O error: unable to open file (", lua_file.string(), ")"));
+        throw Error{ cat("I/O error: unable to open file (", lua_file.string(), ")") };
 
     if (not seq.get_maintainers().empty())
         stream << "-- maintainers: " << seq.get_maintainers() << '\n';
@@ -86,7 +86,7 @@ SequenceManager::SequenceManager(std::filesystem::path path)
     , git_repo_{ path_ }
 {
     if (path_.empty())
-        throw Error("Base path name for sequences must not be empty");
+        throw Error{ "Base path name for sequences must not be empty" };
 }
 
 Sequence
@@ -105,7 +105,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
             return this->write_sequence_to_disk(seq);
         });
     if (not ok)
-        throw Error(cat("Cannot commit sequence copy ", to_string(original_uid)));
+        throw Error{ cat("Cannot commit sequence copy ", to_string(original_uid)) };
 
     return seq;
 }
@@ -122,7 +122,7 @@ SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
             return this->write_sequence_to_disk(seq);
         });
     if (not ok)
-        throw Error(cat("Cannot commit sequence creation ", to_string(unique_id)));
+        throw Error{ cat("Cannot commit sequence creation ", to_string(unique_id)) };
 
     return seq;
 }
@@ -137,7 +137,7 @@ UniqueId SequenceManager::create_unique_id(const std::vector<SequenceOnDisk>& se
             return uid;
     }
 
-    throw Error("Unable to find a unique ID");
+    throw Error{ "Unable to find a unique ID" };
 }
 
 SequenceManager::SequenceOnDisk
@@ -148,7 +148,7 @@ SequenceManager::find_sequence_on_disk(UniqueId uid,
         [uid](const auto& seq) { return seq.unique_id == uid; });
 
     if (it == sequences.end())
-        throw Error(cat("Sequence not found: Unknown unique ID ", to_string(uid)));
+        throw Error{ cat("Sequence not found: Unknown unique ID ", to_string(uid)) };
 
     return *it;
 }
@@ -206,9 +206,9 @@ std::vector<SequenceManager::SequenceOnDisk> SequenceManager::list_sequences() c
         std::filesystem::rename(path_ / folder, path_ / new_folder_name, error);
         if (error)
         {
-            throw Error(gul14::cat("Sequence folder ", folder.string(),
+            throw Error{ gul14::cat("Sequence folder ", folder.string(),
                 " does not contain a unique ID and cannot be renamed to ",
-                new_folder_name, ": ", error.message()));
+                new_folder_name, ": ", error.message()) };
         }
 
         auto seq = load_sequence(unique_id);
@@ -238,9 +238,9 @@ Sequence SequenceManager::load_sequence(UniqueId uid,
     const auto folder = path_ / seq_on_disk.path;
 
     if (not std::filesystem::exists(folder))
-        throw Error(cat("Sequence file path does not exist: ", folder.string()));
+        throw Error{ cat("Sequence file path does not exist: ", folder.string()) };
     else if (not std::filesystem::is_directory(folder))
-        throw Error(cat("Sequence file path is not a directory: ", folder.string()));
+        throw Error{ cat("Sequence file path is not a directory: ", folder.string()) };
 
     Sequence seq{ "", seq_on_disk.name, seq_on_disk.unique_id };
 
@@ -299,13 +299,13 @@ void SequenceManager::remove_sequence(UniqueId unique_id)
             std::filesystem::remove_all(this->path_ / seq_on_disk.path, error);
             if (error)
             {
-                throw Error(cat("Cannot remove sequence folder ",
-                    seq_on_disk.path.string(), ": ", error.message()));
+                throw Error{ cat("Cannot remove sequence folder ",
+                    seq_on_disk.path.string(), ": ", error.message()) };
             }
             return seq_on_disk.path;
         });
     if (not ok)
-        throw Error(cat("Cannot commit sequence removal ", to_string(unique_id)));
+        throw Error{ cat("Cannot commit sequence removal ", to_string(unique_id)) };
 }
 
 void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& new_name)
@@ -322,14 +322,14 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
             std::filesystem::rename(old_path, new_path, error);
             if (error)
             {
-                throw Error(gul14::cat("Cannot rename folder ", old_path.string(),
-                    " to ", new_path.string(), ": ", error.message()));
+                throw Error{ gul14::cat("Cannot rename folder ", old_path.string(),
+                    " to ", new_path.string(), ": ", error.message()) };
             }
             return new_disk_name;
         },
         old_seq_on_disk.path);
     if (not ok)
-        throw Error(cat("Cannot commit sequence rename ", to_string(unique_id)));
+        throw Error{ cat("Cannot commit sequence rename ", to_string(unique_id)) };
 }
 
 void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& new_name)
@@ -345,7 +345,7 @@ void SequenceManager::store_sequence(const Sequence& seq)
             return this->write_sequence_to_disk(seq);
         });
     if (not ok)
-        throw Error(cat("Cannot commit sequence store ", to_string(seq.get_unique_id())));
+        throw Error{ cat("Cannot commit sequence store ", to_string(seq.get_unique_id())) };
 }
 
 std::string SequenceManager::write_sequence_to_disk(const Sequence& seq)
@@ -358,7 +358,7 @@ std::string SequenceManager::write_sequence_to_disk(const Sequence& seq)
     if (not error)
         std::filesystem::create_directories(seq_path, error);
     if (error)
-        throw Error(cat("I/O error: ", error.message()));
+        throw Error{ cat("I/O error: ", error.message()) };
 
     store_sequence_parameters(seq_path / sequence_lua_filename, seq);
 

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -126,7 +126,10 @@ SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
             "': ", error.message()));
     }
 
-    return Sequence{ label, name, unique_id };
+    auto seq = Sequence{ label, name, unique_id };
+    store_sequence(seq, "create");
+
+    return seq;
 }
 
 UniqueId SequenceManager::create_unique_id(const std::vector<SequenceOnDisk>& sequences)
@@ -338,7 +341,7 @@ void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& ne
     sequence.set_name(new_name);
 }
 
-void SequenceManager::store_sequence(const Sequence& seq)
+void SequenceManager::store_sequence(const Sequence& seq, gul14::string_view intent)
 {
     store_sequence_impl(seq);
 
@@ -348,7 +351,7 @@ void SequenceManager::store_sequence(const Sequence& seq)
 
     // commit to local repository
     if (commit_msg != "")
-        git_repo_.commit(gul14::cat("change sequence:", commit_msg));
+        git_repo_.commit(gul14::cat(intent, " sequence:", commit_msg));
 }
 
 void SequenceManager::store_sequence_impl(const Sequence& seq) const

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -74,13 +74,7 @@ void store_sequence_parameters(const std::filesystem::path& lua_file, const Sequ
         stream << "-- maintainers: " << seq.get_maintainers() << '\n';
 
     stream << "-- label: " << seq.get_label() << '\n';
-
-    stream << "-- timeout: ";
-    if (!isfinite(seq.get_timeout()))
-        stream << "infinite\n";
-    else
-        stream << static_cast<std::chrono::milliseconds>(seq.get_timeout()).count() << '\n';
-
+    stream << "-- timeout: " << seq.get_timeout() << '\n';
     stream << seq; // RAII closes the stream (let the destructor do the job)
 }
 

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -198,8 +198,13 @@ bool Step::execute(Context& context, CommChannel* comm, OptionalStepIndex index,
 
 Step& Step::set_disabled(bool disable)
 {
-    is_disabled_ = disable;
-    set_time_of_last_modification(Clock::now());
+    // This setter is allways called from Sequence::enforce_consistency_of_disabled_flags()
+    // We must not change the modification time if we are not modified,
+    // or the modification time will always be the last enforce...() time
+    if (is_disabled_ != disable) {
+        is_disabled_ = disable;
+        set_time_of_last_modification(Clock::now());
+    }
     return *this;
 }
 

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -198,7 +198,7 @@ bool Step::execute(Context& context, CommChannel* comm, OptionalStepIndex index,
 
 Step& Step::set_disabled(bool disable)
 {
-    // This setter is allways called from Sequence::enforce_consistency_of_disabled_flags()
+    // This setter is always called from Sequence::enforce_consistency_of_disabled_flags()
     // We must not change the modification time if we are not modified,
     // or the modification time will always be the last enforce...() time
     if (is_disabled_ != disable) {

--- a/src/serialize_sequence.cc
+++ b/src/serialize_sequence.cc
@@ -76,14 +76,8 @@ std::ostream& operator<<(std::ostream& stream, const Step& step)
     stream << "-- time of last execution: "
         << std::put_time(std::localtime(&execution), "%Y-%m-%d %H:%M:%S") << '\n';
 
-    stream << "-- timeout: ";
-    if (!isfinite(step.get_timeout()))
-        stream << "infinite\n";
-    else
-        stream << static_cast<std::chrono::milliseconds>(step.get_timeout()).count() << '\n';
-
+    stream << "-- timeout: " << step.get_timeout() << '\n';
     stream << "-- disabled: " << std::boolalpha << step.is_disabled() << '\n';
-
     stream << step.get_script() << '\n'; // (Marcus) good practice to add a cr at the end
 
     check_stream(stream);

--- a/subprojects/libgit4cpp.wrap
+++ b/subprojects/libgit4cpp.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+directory = libgit4cpp
+url = https://github.com/taskolib/libgit4cpp.git
+revision = main
+
+[provide]
+libgit4cpp = libgit4cpp_dep

--- a/subprojects/libgit4cpp.wrap
+++ b/subprojects/libgit4cpp.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = libgit4cpp
 url = https://github.com/taskolib/libgit4cpp.git
-revision = main
+revision = feature/globbing
 
 [provide]
 libgit4cpp = libgit4cpp_dep

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -37,7 +37,6 @@
 #include "serialize_sequence.h"
 #include "taskolib/SequenceManager.h"
 
-
 using namespace Catch::Matchers;
 using namespace std::literals;
 using namespace task;
@@ -169,8 +168,7 @@ TEST_CASE("SequenceManager: create_sequence()", "[SequenceManager]")
 TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
 {
     auto root = temp_dir / "sequences";
-    if (std::filesystem::exists(root))
-        std::filesystem::remove_all(root);
+    std::filesystem::remove_all(root);
 
     // prepare first sequence for test
     Step step_1_01{ Step::type_while };

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -574,19 +574,18 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            if (gul14::starts_with(elm.path_name, "git_sequence_1"))
-            {
-                seq_exists = true;
+            if (not gul14::starts_with(elm.path_name, "git_sequence_1"))
+                continue;
+            seq_exists = true;
 
-                // if staging did not work: 
-                //      elm.handling == "untracked"
-                //      elm.changes == "untracked"
-                // if commit did not work
-                //      elm.handling == "staged"
-                //      elm.changes == "new file"
-                REQUIRE(elm.handling == "unchanged");
-                REQUIRE(elm.changes == "unchanged");
-            }
+            // if staging did not work:
+            //      elm.handling == "untracked"
+            //      elm.changes == "untracked"
+            // if commit did not work
+            //      elm.handling == "staged"
+            //      elm.changes == "new file"
+            REQUIRE(elm.handling == "unchanged");
+            REQUIRE(elm.changes == "unchanged");
         }
         // check if created sequence is at least indexed by git
         REQUIRE(seq_exists);
@@ -623,19 +622,18 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            if (gul14::starts_with(elm.path_name, "git_sequence_1[0000abcdef123456]/sequence.lua"))
-            {
-                seq_exists = true;
+            if (not gul14::starts_with(elm.path_name, "git_sequence_1[0000abcdef123456]/sequence.lua"))
+                continue;
+            seq_exists = true;
 
-                // if staging did not work: 
-                //      elm.handling == "unstaged"
-                //      elm.changes == "modified"
-                // if commit did not work
-                //      elm.handling == "staged"
-                //      elm.changes == "modified"
-                REQUIRE(elm.handling == "unchanged");
-                REQUIRE(elm.changes == "unchanged");
-            }
+            // if staging did not work:
+            //      elm.handling == "unstaged"
+            //      elm.changes == "modified"
+            // if commit did not work
+            //      elm.handling == "staged"
+            //      elm.changes == "modified"
+            REQUIRE(elm.handling == "unchanged");
+            REQUIRE(elm.changes == "unchanged");
         }
         // check if created sequence is at least indexed by git
         REQUIRE(seq_exists);
@@ -750,7 +748,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
             {
                 seq_exists = true;
 
-                // if staging did not work: 
+                // if staging did not work:
                 //      elm.handling == "untracked"
                 //      elm.changes == "untracked"
                 // if commit did not work
@@ -787,7 +785,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            // if staging did not work: 
+            // if staging did not work:
             //      elm.handling == "unstaged"
             //      elm.changes == "deleted"
             // if commit did not work

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -76,13 +76,13 @@ std::vector<std::string> collect_lua_filenames(const std::filesystem::path& path
 TEST_CASE("SequenceManager: Constructor with path", "[SequenceManager]")
 {
     std::filesystem::remove_all("./another/path/to/sequences");
-    SequenceManager sm{"./another/path/to/sequences"};
+    SequenceManager sm{ "./another/path/to/sequences" };
     REQUIRE(sm.get_path() == "./another/path/to/sequences");
 }
 
 TEST_CASE("SequenceManager: Move constructor", "[SequenceManager]")
 {
-    SequenceManager s{SequenceManager("unit_test_files")};
+    SequenceManager s{ SequenceManager("unit_test_files") };
     REQUIRE(s.get_path() == "unit_test_files");
 }
 
@@ -173,11 +173,11 @@ TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
         std::filesystem::remove_all(root);
 
     // prepare first sequence for test
-    Step step_1_01{Step::type_while};
+    Step step_1_01{ Step::type_while };
     step_1_01.set_label("while");
     step_1_01.set_script("return i < 10");
 
-    Step step_1_02{Step::type_action};
+    Step step_1_02{ Step::type_action };
     step_1_02.set_label("action");
     step_1_02.set_script("i = i + 1");
 
@@ -256,7 +256,7 @@ TEST_CASE("SequenceManager: load_sequence() - Nonexistent unique ID", "[Sequence
 
     SequenceManager manager{ dir };
 
-    REQUIRE_THROWS_AS(manager.load_sequence(UniqueId{}), Error);
+    REQUIRE_THROWS_AS(manager.load_sequence(UniqueId{ }), Error);
 }
 
 TEST_CASE("SequenceManager: remove_sequence()", "[SequenceManager]")
@@ -364,11 +364,11 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Steps",
     "[SequenceManager]")
 {
     // prepare some sequence for the test
-    Step step_01{Step::type_while};
+    Step step_01{ Step::type_while };
     step_01.set_label("while");
     step_01.set_script("return i < 10");
 
-    Step step_02{Step::type_action};
+    Step step_02{ Step::type_action };
     step_02.set_label("action");
     step_02.set_script("i = i + 1");
 
@@ -407,7 +407,7 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Label, name, UI
     const SequenceName name{ "gabba-gabba_he.Y" };
 
     Sequence sequence{ label, name };
-    sequence.push_back(Step{});
+    sequence.push_back(Step{ });
 
     const auto seq_folder = make_sequence_filename(sequence);
 
@@ -494,7 +494,7 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Maintainers, ti
         std::filesystem::remove_all(temp_dir / make_sequence_filename(seq));
 
     seq.set_maintainers("John Doe john.doe@universe.org; Bob Smith boby@milkyway.edu");
-    seq.set_timeout(task::Timeout{1min});
+    seq.set_timeout(task::Timeout{ 1min });
 
     manager.store_sequence(seq);
 
@@ -502,7 +502,7 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Maintainers, ti
 
     REQUIRE("John Doe john.doe@universe.org; Bob Smith boby@milkyway.edu"
         == seq_deserialized.get_maintainers());
-    REQUIRE(task::Timeout{1min} == seq_deserialized.get_timeout());
+    REQUIRE(task::Timeout{ 1min } == seq_deserialized.get_timeout());
     REQUIRE("Test sequence with maintainers" == seq_deserialized.get_label());
 }
 
@@ -536,7 +536,7 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Empty sequence"
 
 TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 {
-    std::filesystem::path git_dir {"sequences_git"};
+    std::filesystem::path git_dir{ "sequences_git" };
 
     SECTION("Create and store sequence")
     {
@@ -544,11 +544,11 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         std::filesystem::remove_all(git_dir);
 
         // init manager
-        SequenceManager manager{ git_dir};
+        SequenceManager manager{ git_dir };
 
         // create sequence
         Sequence seq{ "git Sequence 1",  SequenceName{ "git_sequence_1" }, UniqueId{ 0xabcdef123456 } };
-        Step step_01{Step::type_while};
+        Step step_01{ Step::type_while };
         step_01.set_label("while");
         step_01.set_script("return i < 10");
         seq.push_back(step_01);
@@ -558,7 +558,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
         // unable to reach repo debug functions without a new function in sequenceManager
         // Therefore a standalone git handler has to be initialized
-        git::GitRepository repo{git_dir};
+        git::GitRepository repo{ git_dir };
 
         // check if commit was done
         const std::string expected_msg = "change sequence:\n- Add sequence.lua from new sequence 'git_sequence_1[0000abcdef123456]'\n- Add step_1_while.lua from new sequence 'git_sequence_1[0000abcdef123456]'";
@@ -592,7 +592,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
     SECTION("change and store sequence (step_setup)")
     {
-        SequenceManager manager{ git_dir};
+        SequenceManager manager{ git_dir };
 
         // load sequence an change step setup
         auto seq = manager.load_sequence(UniqueId{ 0xabcdef123456 });
@@ -608,7 +608,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         // store sequence
         manager.store_sequence(seq);
 
-        git::GitRepository repo{git_dir};
+        git::GitRepository repo{ git_dir };
 
         const std::string expected_msg = "change sequence:\n- modify 'git_sequence_1[0000abcdef123456]/sequence.lua'";
         const auto last_msg = repo.get_last_commit_message();
@@ -640,25 +640,25 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
     SECTION("copy sequence")
     {
-        SequenceManager manager{ git_dir};
+        SequenceManager manager{ git_dir };
 
         // find sequence unique ID
-        UniqueId uID{0};
+        UniqueId uID{ 0 };
         for (auto elm: manager.list_sequences())
         {
-            if (elm.name == SequenceName{"git_sequence_1"}) uID = elm.unique_id;
+            if (elm.name == SequenceName{ "git_sequence_1" }) uID = elm.unique_id;
         }
-        REQUIRE(uID == UniqueId{0xabcdef123456});
+        REQUIRE(uID == UniqueId{ 0xabcdef123456 });
 
-        manager.copy_sequence(UniqueId{0xabcdef123456}, SequenceName{"git_sequence_2"});
+        manager.copy_sequence(UniqueId{ 0xabcdef123456 }, SequenceName{ "git_sequence_2" });
 
-        git::GitRepository repo{git_dir};
+        git::GitRepository repo{ git_dir };
 
         // find sequence full name
-        std::filesystem::path seq_name{""};
+        std::filesystem::path seq_name{ "" };
         for (auto elm: manager.list_sequences())
         {
-            if (elm.name == SequenceName{"git_sequence_2"}) seq_name = elm.path;
+            if (elm.name == SequenceName{ "git_sequence_2" }) seq_name = elm.path;
         }
         REQUIRE(seq_name != "");
 
@@ -679,7 +679,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
             {
                 seq_exists = true;
 
-                // if staging did not work: 
+                // if staging did not work:
                 //      elm.handling == "untracked"
                 //      elm.changes == "untracked"
                 // if commit did not work
@@ -696,35 +696,35 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
     SECTION("rename sequence")
     {
-        SequenceManager manager{ git_dir};
+        SequenceManager manager{ git_dir };
 
         // find sequence unique ID and full name
-        UniqueId uID{0};
-        std::filesystem::path seq2{""};
+        UniqueId uID{ 0 };
+        std::filesystem::path seq2{ "" };
         for (auto elm: manager.list_sequences())
         {
-            if (elm.name == SequenceName{"git_sequence_2"})
+            if (elm.name == SequenceName{ "git_sequence_2" })
             {
                 uID = elm.unique_id;
                 seq2 = elm.path;
             }
         }
-        REQUIRE(uID != UniqueId{0});
+        REQUIRE(uID != UniqueId{ 0 });
         REQUIRE(seq2 != "");
 
 
-        manager.rename_sequence(uID, SequenceName{"git_sequence_3"});
+        manager.rename_sequence(uID, SequenceName{ "git_sequence_3" });
 
         // find sequence paths
-        std::filesystem::path seq3{""};
+        std::filesystem::path seq3{ "" };
         for (auto elm: manager.list_sequences())
         {
-            
-            if (elm.name == SequenceName{"git_sequence_3"}) seq3 = elm.path;
+
+            if (elm.name == SequenceName{ "git_sequence_3" }) seq3 = elm.path;
         }
         REQUIRE(seq3 != "");
 
-        git::GitRepository repo{git_dir};
+        git::GitRepository repo{ git_dir };
 
         const std::string expected_msg = gul14::cat("Rename git_sequence_2 to git_sequence_3:\n",
                                                      "- delete '", seq2.string(), "/sequence.lua'\n",
@@ -762,13 +762,13 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
     SECTION("remove sequence")
     {
-        SequenceManager manager{ git_dir};
+        SequenceManager manager{ git_dir };
 
         manager.remove_sequence(UniqueId{ 0xabcdef123456 });
 
         // create object here so that manager.store_sequence throws error
         // if init repository did not work
-        git::GitRepository repo{git_dir};
+        git::GitRepository repo{ git_dir };
 
         const std::string expected_msg = gul14::cat("remove sequence:\n",
                                                      "- delete 'git_sequence_1[0000abcdef123456]/sequence.lua'\n",

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -563,7 +563,9 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         git::GitRepository repo{ git_dir };
 
         // check if commit was done
-        const std::string expected_msg = "change sequence:\n- Add sequence.lua from new sequence 'git_sequence_1[0000abcdef123456]'\n- Add step_1_while.lua from new sequence 'git_sequence_1[0000abcdef123456]'";
+        const std::string expected_msg = "Modify sequence git_sequence_1[0000abcdef123456]\n\n"
+            "- new file: sequence.lua\n"
+            "- new file: step_1_while.lua";
         const auto last_msg = repo.get_last_commit_message();
         REQUIRE(expected_msg == last_msg);
 
@@ -612,7 +614,8 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
         git::GitRepository repo{ git_dir };
 
-        const std::string expected_msg = "change sequence:\n- modify 'git_sequence_1[0000abcdef123456]/sequence.lua'";
+        const std::string expected_msg = "Modify sequence git_sequence_1[0000abcdef123456]\n\n"
+            "- modified: sequence.lua";
         const auto last_msg = repo.get_last_commit_message();
         REQUIRE(expected_msg == last_msg);
 
@@ -665,9 +668,10 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         REQUIRE(seq_name != "");
 
         // check commit message
-        const std::string expected_msg = gul14::cat("copy sequence:\n- Add sequence.lua from new sequence '",
-                                                     seq_name.string(), "'\n- Add step_1_while.lua from new sequence '",
-                                                     seq_name.string(), "'");
+        const std::string expected_msg = gul14::cat("Copy sequence git_sequence_1[0000abcdef123456] "
+            "to ", seq_name.string(), "\n\n"
+            "- new file: sequence.lua\n"
+            "- new file: step_1_while.lua");
         const auto last_msg = repo.get_last_commit_message();
         REQUIRE(expected_msg == last_msg);
 
@@ -728,11 +732,13 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
         git::GitRepository repo{ git_dir };
 
-        const std::string expected_msg = gul14::cat("Rename git_sequence_2 to git_sequence_3:\n",
-                                                     "- delete '", seq2.string(), "/sequence.lua'\n",
-                                                     "- delete '", seq2.string(), "/step_1_while.lua'\n"
-                                                     "- Add sequence.lua from new sequence '", seq3.string(), "'\n"
-                                                     "- Add step_1_while.lua from new sequence '", seq3.string(), "'");
+        const std::string expected_msg = gul14::cat("Rename ",
+            seq2.string(), " to ", seq3.string(), "\n\n",
+            "- deleted: sequence.lua\n"
+            "- deleted: step_1_while.lua\n"
+            "- new file: sequence.lua\n"
+            "- new file: step_1_while.lua");
+
         const auto last_msg = repo.get_last_commit_message();
         REQUIRE(expected_msg == last_msg);
 
@@ -772,9 +778,9 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         // if init repository did not work
         git::GitRepository repo{ git_dir };
 
-        const std::string expected_msg = gul14::cat("remove sequence:\n",
-                                                     "- delete 'git_sequence_1[0000abcdef123456]/sequence.lua'\n",
-                                                     "- delete 'git_sequence_1[0000abcdef123456]/step_1_while.lua'");
+        const std::string expected_msg = "Remove sequence git_sequence_1[0000abcdef123456]\n\n"
+            "- deleted: sequence.lua\n"
+            "- deleted: step_1_while.lua";
         const auto last_msg = repo.get_last_commit_message();
         REQUIRE(expected_msg == last_msg);
 

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -30,10 +30,13 @@
 #include <vector>
 
 #include <gul14/catch.h>
+#include<gul14/substring_checks.h>
+#include <libgit4cpp/GitRepository.h>
 
 #include "internals.h"
 #include "serialize_sequence.h"
 #include "taskolib/SequenceManager.h"
+
 
 using namespace Catch::Matchers;
 using namespace std::literals;
@@ -72,12 +75,14 @@ std::vector<std::string> collect_lua_filenames(const std::filesystem::path& path
 
 TEST_CASE("SequenceManager: Constructor with path", "[SequenceManager]")
 {
+    std::filesystem::remove_all("./another/path/to/sequences");
     SequenceManager sm{"./another/path/to/sequences"};
     REQUIRE(sm.get_path() == "./another/path/to/sequences");
 }
 
 TEST_CASE("SequenceManager: Move constructor", "[SequenceManager]")
 {
+    std::filesystem::remove_all("unit_test_files");
     SequenceManager s{SequenceManager("unit_test_files")};
     REQUIRE(s.get_path() == "unit_test_files");
 }
@@ -164,6 +169,10 @@ TEST_CASE("SequenceManager: create_sequence()", "[SequenceManager]")
 
 TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
 {
+    const std::string root = "unit_test_files/sequences";
+    if (std::filesystem::exists(root))
+    std::filesystem::remove_all(root);
+
     // prepare first sequence for test
     Step step_1_01{Step::type_while};
     step_1_01.set_label("while");
@@ -190,12 +199,7 @@ TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
     seq_2.push_back(step_1_01);
     seq_2.push_back(step_1_02);
 
-
-    const std::string root = "unit_test_files/sequences";
     SequenceManager manager{ root };
-
-    if (std::filesystem::exists(root))
-        std::filesystem::remove_all(root);
 
     manager.store_sequence(seq_1);
     manager.store_sequence(seq_2);
@@ -528,4 +532,267 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Empty sequence"
         Sequence seq_deserialized = manager.load_sequence(seq.get_unique_id());
         REQUIRE(seq_deserialized.empty());
     }
+}
+
+
+TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
+{
+
+    SECTION("Create and store sequence")
+    {
+        // clean surrounding
+        std::filesystem::remove_all(temp_dir);
+
+        // init manager
+        SequenceManager manager{ temp_dir};
+
+        // create sequence
+        Sequence seq{ "git Sequence 1",  SequenceName{ "git_sequence_1" }, UniqueId{ 0xabcdef123456 } };
+        Step step_01{Step::type_while};
+        step_01.set_label("while");
+        step_01.set_script("return i < 10");
+        seq.push_back(step_01);
+
+        // store sequence and make git commit
+        manager.store_sequence(seq);
+
+        // unable to reach gl debug functions without a new function in sequenceManager
+        // Therefore a standalone git handler has to be initialized
+        git::GitRepository gl{temp_dir};
+
+        // check if commit was done
+        const std::string& expected_msg = "change sequence:\n- Add sequence.lua from new sequence 'git_sequence_1[0000abcdef123456]'\n- Add step_1_while.lua from new sequence 'git_sequence_1[0000abcdef123456]'";
+        const auto& last_msg = gl.get_last_commit_message();
+        REQUIRE(expected_msg == last_msg);
+
+
+        // use raw repository to access status
+        const auto stats = gl.status();
+        REQUIRE(stats.size() != 0);
+        bool seq_exists = false;
+        for(const auto& elm: stats)
+        {
+            if (gul14::starts_with(elm.path_name, "git_sequence_1"))
+            {
+                seq_exists = true;
+
+                // if staging did not work: 
+                //      elm.handling == "untracked"
+                //      elm.changes == "untracked"
+                // if commit did not work
+                //      elm.handling == "staged"
+                //      elm.changes == "new file"
+                REQUIRE(elm.handling == "unchanged");
+                REQUIRE(elm.changes == "unchanged");
+
+            }
+        }
+        // check if created sequence is at least indexed by git
+        REQUIRE(seq_exists);
+    }
+
+    SECTION("change and store sequence (step_setup)")
+    {
+        SequenceManager manager{ temp_dir};
+
+        // load sequence an change step setup
+        auto seq = manager.load_sequence(UniqueId{ 0xabcdef123456 });
+        const auto step_setup_script =
+        R"(
+        a = 'Bob'
+        function test(name)
+            return name .. ' with some funky stuff!'
+        end
+        b = test('Alice') \t\b\b  c = 4)";
+        seq.set_step_setup_script(step_setup_script);
+
+        // store sequence
+        manager.store_sequence(seq);
+
+        git::GitRepository gl{temp_dir};
+
+        const std::string& expected_msg = "change sequence:\n- modify 'git_sequence_1[0000abcdef123456]/sequence.lua'";
+        const auto& last_msg = gl.get_last_commit_message();
+        REQUIRE(expected_msg == last_msg);
+
+        // use raw repository to access status
+        const auto stats = gl.status();
+        REQUIRE(stats.size() != 0);
+        bool seq_exists = false;
+        for(const auto& elm: stats)
+        {
+            if (gul14::starts_with(elm.path_name, "git_sequence_1[0000abcdef123456]/sequence.lua"))
+            {
+                seq_exists = true;
+
+                // if staging did not work: 
+                //      elm.handling == "unstaged"
+                //      elm.changes == "modified"
+                // if commit did not work
+                //      elm.handling == "staged"
+                //      elm.changes == "modified"
+                REQUIRE(elm.handling == "unchanged");
+                REQUIRE(elm.changes == "unchanged");
+
+            }
+        }
+        // check if created sequence is at least indexed by git
+        REQUIRE(seq_exists);
+    }
+
+    SECTION("copy sequence")
+    {
+        SequenceManager manager{ temp_dir};
+
+        // find sequence unique ID
+        UniqueId uID{0};
+        for (auto elm: manager.list_sequences())
+        {
+            if (elm.name == SequenceName{"git_sequence_1"}) uID = elm.unique_id;
+        }
+        REQUIRE(uID == UniqueId{0xabcdef123456});
+
+        manager.copy_sequence(UniqueId{0xabcdef123456}, SequenceName{"git_sequence_2"});
+
+        git::GitRepository gl{temp_dir};
+
+        // find sequence full name
+        std::filesystem::path seq_name{""};
+        for (auto elm: manager.list_sequences())
+        {
+            if (elm.name == SequenceName{"git_sequence_2"}) seq_name = elm.path;
+        }
+        REQUIRE(seq_name != "");
+
+        // check commit message
+        const std::string& expected_msg = gul14::cat("copy sequence:\n- Add sequence.lua from new sequence '",
+                                                     seq_name.string(), "'\n- Add step_1_while.lua from new sequence '",
+                                                     seq_name.string(), "'");
+        const auto& last_msg = gl.get_last_commit_message();
+        REQUIRE(expected_msg == last_msg);
+
+        // use raw repository to access status
+        const auto stats = gl.status();
+        REQUIRE(stats.size() != 0);
+        bool seq_exists = false;
+        for(const auto& elm: stats)
+        {
+            if (gul14::starts_with(elm.path_name, "git_sequence_2"))
+            {
+                seq_exists = true;
+
+                // if staging did not work: 
+                //      elm.handling == "untracked"
+                //      elm.changes == "untracked"
+                // if commit did not work
+                //      elm.handling == "staged"
+                //      elm.changes == "new file"
+                REQUIRE(elm.handling == "unchanged");
+                REQUIRE(elm.changes == "unchanged");
+
+            }
+        }
+        // check if created sequence is at least indexed by git
+        REQUIRE(seq_exists);
+    }
+
+    SECTION("rename sequence")
+    {
+        SequenceManager manager{ temp_dir};
+
+        // find sequence unique ID and full name
+        UniqueId uID{0};
+        std::filesystem::path seq2{""};
+        for (auto elm: manager.list_sequences())
+        {
+            if (elm.name == SequenceName{"git_sequence_2"})
+            {
+                uID = elm.unique_id;
+                seq2 = elm.path;
+            }
+        }
+        REQUIRE(uID != UniqueId{0});
+        REQUIRE(seq2 != "");
+
+
+        manager.rename_sequence(uID, SequenceName{"git_sequence_3"});
+
+        // find sequence paths
+        std::filesystem::path seq3{""};
+        for (auto elm: manager.list_sequences())
+        {
+            
+            if (elm.name == SequenceName{"git_sequence_3"}) seq3 = elm.path;
+        }
+        REQUIRE(seq3 != "");
+
+        git::GitRepository gl{temp_dir};
+
+        const std::string& expected_msg = gul14::cat("Rename git_sequence_2 to git_sequence_3:\n",
+                                                     "- delete '", seq2.string(), "/sequence.lua'\n",
+                                                     "- delete '", seq2.string(), "/step_1_while.lua'\n"
+                                                     "- Add sequence.lua from new sequence '", seq3.string(), "'\n"
+                                                     "- Add step_1_while.lua from new sequence '", seq3.string(), "'");
+        const auto& last_msg = gl.get_last_commit_message();
+        REQUIRE(expected_msg == last_msg);
+
+        // use raw repository to access status
+        const auto stats = gl.status();
+        REQUIRE(stats.size() != 0);
+        bool seq_exists = false;
+        for(const auto& elm: stats)
+        {
+            if (gul14::starts_with(elm.path_name, "git_sequence_3"))
+            {
+                seq_exists = true;
+
+                // if staging did not work: 
+                //      elm.handling == "untracked"
+                //      elm.changes == "untracked"
+                // if commit did not work
+                //      elm.handling == "staged"
+                //      elm.changes == "new file"
+                REQUIRE(elm.handling == "unchanged");
+                REQUIRE(elm.changes == "unchanged");
+
+            }
+        }
+        // check if created sequence is at least indexed by git
+        REQUIRE(seq_exists);
+
+    }
+
+    SECTION("remove sequence")
+    {
+        SequenceManager manager{ temp_dir};
+
+        manager.remove_sequence(UniqueId{ 0xabcdef123456 });
+
+        // create object here so that manager.store_sequence throws error
+        // if init repository did not work
+        git::GitRepository gl{temp_dir};
+
+        const std::string& expected_msg = gul14::cat("remove sequence:\n",
+                                                     "- delete 'git_sequence_1[0000abcdef123456]/sequence.lua'\n",
+                                                     "- delete 'git_sequence_1[0000abcdef123456]/step_1_while.lua'");
+        const auto& last_msg = gl.get_last_commit_message();
+        REQUIRE(expected_msg == last_msg);
+
+        // use raw repository to access status
+        const auto stats = gl.status();
+        bool seq_exists = false;
+        for(const auto& elm: stats)
+        {
+            // if staging did not work: 
+            //      elm.handling == "unstaged"
+            //      elm.changes == "deleted"
+            // if commit did not work
+            //      elm.handling == "staged"
+            //      elm.changes == "deleted"
+            REQUIRE(! gul14::starts_with(elm.path_name, "git_sequence_1"));
+        }
+        // check if sequence got removed from index
+        REQUIRE(! seq_exists);
+    }
+
 }

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -30,7 +30,7 @@
 #include <vector>
 
 #include <gul14/catch.h>
-#include<gul14/substring_checks.h>
+#include <gul14/substring_checks.h>
 #include <libgit4cpp/GitRepository.h>
 
 #include "internals.h"
@@ -82,7 +82,6 @@ TEST_CASE("SequenceManager: Constructor with path", "[SequenceManager]")
 
 TEST_CASE("SequenceManager: Move constructor", "[SequenceManager]")
 {
-    std::filesystem::remove_all("unit_test_files");
     SequenceManager s{SequenceManager("unit_test_files")};
     REQUIRE(s.get_path() == "unit_test_files");
 }
@@ -171,7 +170,7 @@ TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
 {
     const std::string root = "unit_test_files/sequences";
     if (std::filesystem::exists(root))
-    std::filesystem::remove_all(root);
+        std::filesystem::remove_all(root);
 
     // prepare first sequence for test
     Step step_1_01{Step::type_while};

--- a/tests/test_Timeout.cc
+++ b/tests/test_Timeout.cc
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <stdexcept>
+#include <sstream>
 
 #include <gul14/catch.h>
 
@@ -142,4 +143,22 @@ TEST_CASE("Timeout: Comparison operators", "[Timeout]")
         REQUIRE((t1 >= t0) == true);
         REQUIRE((t0 >= t1) == false);
     }
+}
+
+TEST_CASE("Timeout: Dump to stream", "[Timeout]")
+{
+    auto t = Timeout{ 0s };
+    std::stringstream ss{ };
+    ss << t;
+    REQUIRE(ss.str() == "0");
+
+    t = Timeout{ 10s };
+    ss.str("");
+    ss << t;
+    REQUIRE(ss.str() == "10000");
+
+    t = Timeout::infinity();
+    ss.str("");
+    ss << t;
+    REQUIRE(ss.str() == "infinite");
 }

--- a/tests/test_format.cc
+++ b/tests/test_format.cc
@@ -32,12 +32,6 @@
 
 using namespace task;
 
-TEST_CASE("format: TimePoint", "[format]")
-{
-    auto x = fmt::format("{}", TimePoint{ });
-    REQUIRE(x == "1970-01-01 00:00:00 UTC");
-}
-
 TEST_CASE("format: Message", "[format]")
 {
     Message msg;
@@ -49,4 +43,18 @@ TEST_CASE("format: Message", "[format]")
 
     auto x = fmt::format("{}", msg);
     REQUIRE(gul14::trim(x) == "Message{ 32: step_started \"Beware of the foxes\" 1970-01-01 00:00:00 UTC }");
+}
+
+TEST_CASE("format: Timeout", "[format]")
+{
+    auto x = fmt::format("{}", Timeout{ 0s });
+    REQUIRE(x == "0");
+    x = fmt::format("{}", Timeout::infinity());
+    REQUIRE(x == "infinite");
+}
+
+TEST_CASE("format: TimePoint", "[format]")
+{
+    auto x = fmt::format("{}", TimePoint{ });
+    REQUIRE(x == "1970-01-01 00:00:00 UTC");
 }


### PR DESCRIPTION
closes #73

### What has to be changed
- remove 'const' property from all SequenceManager functions which may trigger a git commit
- Functions which trigger a git commit
   - copy_sequence
   - remove_sequence
   - rename_sequence
   - store_sequence
### What has been done
- add function stage_files_in_directory
   - loop over all files in repository directory via "git status" 
   - add or remove particular files from index (stage)
   - cumulate a commit message from each file handling
   - only choose files inside current sequence
- call commit after staging

### open points
- If two sequences are changed at the same time it may be possible that both changes end up in same commit
- handling of removal of files from index is not esthetic
- store only & only on main branch. There is no functionality for eg. git reset, git branch or git merge. It has to be done manually if needed.

Fixes: #106
Fixes: #82