### PR TITLE
Disallow sequence names starting with a period

### DIFF
--- a/include/taskolib/SequenceName.h
+++ b/include/taskolib/SequenceName.h
@@ -37,7 +37,8 @@ namespace task {
  *
  * A sequence name has constraints on its length and the contained characters. It may be
  * at most max_length bytes long and it may only contain upper- and lowercase letters,
- * digits, the minus and underscore characters, and periods.
+ * digits, the minus and underscore characters, and periods. It may not start with a
+ * period.
  */
 class SequenceName
 {

--- a/src/SequenceName.cc
+++ b/src/SequenceName.cc
@@ -24,9 +24,12 @@
 
 #include <gul14/cat.h>
 #include <gul14/escape.h>
+#include <gul14/substring_checks.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/SequenceName.h"
+
+using gul14::cat;
 
 namespace task {
 
@@ -38,16 +41,18 @@ gul14::string_view SequenceName::check_validity(gul14::string_view str)
 {
     if (str.size() > max_length)
     {
-        throw Error(gul14::cat("Sequence name '", str, "' is too long: ", str.size(),
+        throw Error(cat("Sequence name '", str, "' is too long: ", str.size(),
             " bytes > ", max_length, " bytes"));
     }
 
-    if (str.find_first_not_of(valid_characters)
-        != gul14::string_view::npos)
+    if (str.find_first_not_of(valid_characters) != gul14::string_view::npos)
     {
-        throw Error(gul14::cat("Sequence name '", gul14::escape(str),
+        throw Error(cat("Sequence name '", gul14::escape(str),
             "' contains invalid characters"));
     }
+
+    if (gul14::starts_with(str, '.'))
+        throw Error(cat("A sequence name may not start with a period ('", str, "'"));
 
     return str;
 }

--- a/tests/test_SequenceName.cc
+++ b/tests/test_SequenceName.cc
@@ -46,6 +46,7 @@ TEST_CASE("SequenceName: Constructor from string", "[SequenceName]")
     REQUIRE_THROWS_AS(SequenceName{ "abcd#e" }, Error);
     REQUIRE_THROWS_AS(SequenceName{ "abcd(e)" }, Error);
     REQUIRE_THROWS_AS(SequenceName{ "abcd[e]" }, Error);
+    REQUIRE_THROWS_AS(SequenceName{ ".abcd" }, Error);
 }
 
 TEST_CASE("SequenceName: from_string()", "[SequenceName]")
@@ -60,6 +61,7 @@ TEST_CASE("SequenceName: from_string()", "[SequenceName]")
     REQUIRE(SequenceName::from_string("abcd#e") == gul14::nullopt);
     REQUIRE(SequenceName::from_string("abcd(e)") == gul14::nullopt);
     REQUIRE(SequenceName::from_string("abcd[e]") == gul14::nullopt);
+    REQUIRE(SequenceName::from_string(".abcd") == gul14::nullopt);
 }
 
 TEST_CASE("SequenceName: operator==()", "[SequenceName]")


### PR DESCRIPTION
Sequence names are designed to be machine-friendly, and as such are often used as folder or file names. On unixoid operating systems, file names starting with a period designate hidden files. We might want to avoid that by requiring that the first character of a sequence name must not be a period (".").

Closes #98.