### PR TITLE
Bugfix: Correct error info when erasing or inserting steps

### DIFF
--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -274,8 +274,25 @@ void Sequence::enforce_invariants()
 
 Sequence::ConstIterator Sequence::erase(Sequence::ConstIterator iter)
 {
+    const auto erased_idx = std::distance(cbegin(), iter);
+
     throw_if_running();
     auto return_iter = steps_.erase(iter);
+
+    if (error_.has_value())
+    {
+        auto maybe_idx = error_->get_index();
+        if (maybe_idx.has_value())
+        {
+            const auto error_idx = *maybe_idx;
+
+            if (erased_idx == error_idx)
+                error_->set_index(gul14::nullopt);
+            else if (erased_idx < error_idx)
+                error_->set_index(error_idx - 1);
+        }
+    }
+
     enforce_invariants();
     return return_iter;
 }
@@ -283,8 +300,26 @@ Sequence::ConstIterator Sequence::erase(Sequence::ConstIterator iter)
 Sequence::ConstIterator Sequence::erase(Sequence::ConstIterator begin,
                                         Sequence::ConstIterator end)
 {
+    const auto erased_begin_idx = std::distance(cbegin(), begin);
+    const auto erased_end_idx = std::distance(cbegin(), end);
+
     throw_if_running();
     auto return_iter = steps_.erase(begin, end);
+
+    if (error_.has_value())
+    {
+        auto maybe_idx = error_->get_index();
+        if (maybe_idx.has_value())
+        {
+            const auto error_idx = *maybe_idx;
+
+            if (error_idx >= erased_begin_idx && error_idx < erased_end_idx)
+                error_->set_index(gul14::nullopt);
+            else if (error_idx >= erased_end_idx)
+                error_->set_index(error_idx - (erased_end_idx - erased_begin_idx));
+        }
+    }
+
     enforce_invariants();
     return return_iter;
 }

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -685,7 +685,10 @@ void Sequence::pop_back()
 {
     throw_if_running();
     if (not steps_.empty())
+    {
+        correct_error_index_after_step_erased(steps_.end() - 1);
         steps_.pop_back();
+    }
     enforce_invariants();
 }
 

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -323,6 +323,10 @@ Sequence::ConstIterator Sequence::erase(Sequence::ConstIterator begin,
     const auto erased_end_idx = std::distance(cbegin(), end);
 
     throw_if_running();
+
+    if (begin > end)
+        throw Error("Invalid range: begin > end");
+
     auto return_iter = steps_.erase(begin, end);
 
     if (error_.has_value())

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -126,8 +126,8 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
     // Execute the script so that it fails at index 2 and the sequence stores error info
     Context context;
     auto err = seq.execute(context, nullptr);
-    REQUIRE(err.has_value() == true);
-    REQUIRE(err->get_index().has_value() == true);
+    REQUIRE(err.has_value());
+    REQUIRE(err->get_index().has_value());
     REQUIRE(err->get_index().value() == 2);
 
     SECTION("erase first (iterator)")
@@ -146,7 +146,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(not seq.empty());
         REQUIRE(4 == seq.size());
         REQUIRE(Step::type_end == (*erase).get_type());
-        REQUIRE(seq.get_error().has_value() == true);
+        REQUIRE(seq.get_error().has_value());
         REQUIRE(seq.get_error()->get_index().has_value() == false);
     }
 
@@ -216,14 +216,14 @@ TEST_CASE("Sequence: get_error()", "[Sequence]")
     REQUIRE(seq.get_error().has_value() == false);
 
     seq.set_error(Error{ "Test", gul14::nullopt });
-    REQUIRE(seq.get_error().has_value() == true);
+    REQUIRE(seq.get_error().has_value());
     REQUIRE(seq.get_error()->what() == "Test"s);
     REQUIRE(seq.get_error()->get_index().has_value() == false);
 
     seq.set_error(Error{ "Test2", 42 });
-    REQUIRE(seq.get_error().has_value() == true);
+    REQUIRE(seq.get_error().has_value());
     REQUIRE(seq.get_error()->what() == "Test2"s);
-    REQUIRE(seq.get_error()->get_index().has_value() == true);
+    REQUIRE(seq.get_error()->get_index().has_value());
     REQUIRE(seq.get_error()->get_index().value() == 42);
 }
 
@@ -267,8 +267,8 @@ TEST_CASE("Sequence: insert()", "[Sequence]")
     // Execute the script so that it fails at index 1 and the sequence stores error info
     Context context;
     auto err = seq.execute(context, nullptr);
-    REQUIRE(err.has_value() == true);
-    REQUIRE(err->get_index().has_value() == true);
+    REQUIRE(err.has_value());
+    REQUIRE(err->get_index().has_value());
     REQUIRE(err->get_index().value() == 1);
 
     SECTION("insert const reference")
@@ -323,7 +323,7 @@ TEST_CASE("Sequence: is_running()", "[Sequence]")
     REQUIRE(not seq.is_running());
 
     seq.set_running(true);
-    REQUIRE(seq.is_running() == true);
+    REQUIRE(seq.is_running());
 
     seq.set_running(false);
     REQUIRE(seq.is_running() == false);
@@ -414,8 +414,8 @@ TEST_CASE("Sequence: pop_back()", "[Sequence]")
     // Execute the script so that it fails at index 1 and the sequence stores error info
     Context context;
     auto err = seq.execute(context, nullptr);
-    REQUIRE(err.has_value() == true);
-    REQUIRE(err->get_index().has_value() == true);
+    REQUIRE(err.has_value());
+    REQUIRE(err->get_index().has_value());
     REQUIRE(err->get_index().value() == 1);
 
     seq.pop_back();
@@ -465,9 +465,9 @@ TEST_CASE("Sequence: set_error()", "[Sequence]")
     Sequence seq{ "test_sequence" };
 
     seq.set_error(Error{ "Test", 42 });
-    REQUIRE(seq.get_error().has_value() == true);
+    REQUIRE(seq.get_error().has_value());
     REQUIRE(seq.get_error()->what() == "Test"s);
-    REQUIRE(seq.get_error()->get_index().has_value() == true);
+    REQUIRE(seq.get_error()->get_index().has_value());
     REQUIRE(seq.get_error()->get_index().value() == 42);
 
     seq.set_error(gul14::nullopt);
@@ -501,7 +501,7 @@ TEST_CASE("Sequence: set_running()", "[Sequence]")
     seq.push_back(step1);
 
     seq.set_running(true);
-    REQUIRE(seq.is_running() == true);
+    REQUIRE(seq.is_running());
 
     SECTION("Sequence can be modified while not is_running()")
     {
@@ -1361,9 +1361,9 @@ TEST_CASE("execute(): complex sequence with prohibited Lua function", "[Sequence
     sequence.push_back(step);
 
     auto maybe_error = sequence.execute(context, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE(maybe_error->what() != ""s);
-    REQUIRE(maybe_error->get_index().has_value() == true);
+    REQUIRE(maybe_error->get_index().has_value());
     REQUIRE(maybe_error->get_index().value() == 0);
 
     REQUIRE(sequence.get_error() == maybe_error);
@@ -1390,9 +1390,9 @@ TEST_CASE("execute(): complex sequence with disallowed 'function' and context "
     sequence.push_back(step_action2);
 
     auto maybe_error = sequence.execute(context, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE(maybe_error->what() != ""s);
-    REQUIRE(maybe_error->get_index().has_value() == true);
+    REQUIRE(maybe_error->get_index().has_value());
     REQUIRE(maybe_error->get_index().value() == 0);
 
     REQUIRE(sequence.get_error() == maybe_error);
@@ -2007,7 +2007,7 @@ TEST_CASE("execute(): faulty if-else-elseif sequence", "[Sequence]")
 
     auto maybe_error = sequence.execute(context, nullptr);
 
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE(maybe_error->what() != ""s);
     REQUIRE(maybe_error->get_index().has_value() == false);
 
@@ -2359,9 +2359,9 @@ TEST_CASE("execute(): simple try sequence with fault", "[Sequence]")
     context.variables["a"] = VarInteger{ 0 };
 
     auto maybe_error = sequence.execute(context, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE(maybe_error->what() != ""s);
-    REQUIRE(maybe_error->get_index().has_value() == true);
+    REQUIRE(maybe_error->get_index().has_value());
     REQUIRE(maybe_error->get_index().value() == 5);
     REQUIRE(sequence.get_error() == maybe_error);
     REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
@@ -2460,7 +2460,7 @@ TEST_CASE("execute(): complex try sequence with fault", "[Sequence]")
 
     Context context;
     auto maybe_error = sequence.execute(context, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
 
     REQUIRE(std::get<VarInteger>(context.variables["a"]) == 2);
 }
@@ -2962,7 +2962,7 @@ TEST_CASE("execute(): complex sequence with misplaced if", "[Sequence]")
     Context context;
 
     auto maybe_error = sequence.execute(context, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
 }
 
 TEST_CASE("execute_sequence(): Messages", "[execute_sequence]")
@@ -3682,14 +3682,14 @@ TEST_CASE("execute(): Disable + re-enable action inside while loop", "[Sequence]
     SECTION("Disable WHILE, then attempt to re-enable ACTION")
     {
         s.modify(s.begin(), [](Step& st) { st.set_disabled(true); });
-        REQUIRE(s[0].is_disabled() == true);
-        REQUIRE(s[1].is_disabled() == true);
-        REQUIRE(s[2].is_disabled() == true);
+        REQUIRE(s[0].is_disabled());
+        REQUIRE(s[1].is_disabled());
+        REQUIRE(s[2].is_disabled());
 
         s.modify(s.begin() + 1, [](Step& st) { st.set_disabled(false); });
-        REQUIRE(s[0].is_disabled() == true);
-        REQUIRE(s[1].is_disabled() == true);
-        REQUIRE(s[2].is_disabled() == true);
+        REQUIRE(s[0].is_disabled());
+        REQUIRE(s[1].is_disabled());
+        REQUIRE(s[2].is_disabled());
     }
 }
 
@@ -3735,9 +3735,9 @@ TEST_CASE("execute(): Single step", "[Sequence]")
     SECTION("Index 2 (ACTION step): Script is executed")
     {
         auto maybe_error = sequence.execute(context, nullptr, 2);
-        REQUIRE(maybe_error.has_value() == true);
+        REQUIRE(maybe_error.has_value());
         REQUIRE_THAT(maybe_error->what(), Contains("Action Boom"));
-        REQUIRE(maybe_error->get_index().has_value() == true);
+        REQUIRE(maybe_error->get_index().has_value());
         REQUIRE(maybe_error->get_index().value() == 2);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 3 });
     }
@@ -3909,7 +3909,7 @@ TEST_CASE("Sequence: Check line number on failure (setup at line 2)", "[Sequence
         )");
 
     auto maybe_error = seq.execute(ctx, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE_THAT(maybe_error->what(), Catch::Matchers::StartsWith("[setup] 2: syntax error"));
 }
 
@@ -3929,7 +3929,7 @@ TEST_CASE("Sequence: Check line number on failure (script at line 2)", "[Sequenc
     seq.set_step_setup_script("preface = 'Alice'");
 
     auto maybe_error = seq.execute(ctx, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE_THAT(maybe_error->what(), Catch::Matchers::StartsWith("2: syntax error"));
 }
 
@@ -3950,7 +3950,7 @@ TEST_CASE("Sequence: Check line number on failure (script at line 3)", "[Sequenc
     seq.set_step_setup_script("preface = 'Alice'");
 
     auto maybe_error = seq.execute(ctx, nullptr);
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE_THAT(maybe_error->what(), Catch::Matchers::StartsWith("3: syntax error"));
 }
 
@@ -3992,7 +3992,7 @@ TEST_CASE("Sequence: sequence timeout", "[Sequence]")
     auto maybe_error = seq.execute(ctx, nullptr);
     REQUIRE(seq.get_time_of_last_execution() != task::TimePoint{});
 
-    REQUIRE(maybe_error.has_value() == true);
+    REQUIRE(maybe_error.has_value());
     REQUIRE_THAT(maybe_error->what(), Contains("Timeout: Sequence"));
 }
 

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -403,13 +403,25 @@ TEST_CASE("Sequence: modify()", "[Sequence]")
 TEST_CASE("Sequence: pop_back()", "[Sequence]")
 {
     Sequence seq{ "test_sequence" };
-    seq.push_back(Step{});
-    seq.push_back(Step{});
+    seq.push_back(Step{}); // idx 0
+
+    Step step{ Step::type_action };
+    step.set_script("not a valid Lua script");
+    seq.push_back(step); // idx 1
     REQUIRE(seq.empty() == false);
     REQUIRE(seq.size() == 2);
 
+    // Execute the script so that it fails at index 1 and the sequence stores error info
+    Context context;
+    auto err = seq.execute(context, nullptr);
+    REQUIRE(err.has_value() == true);
+    REQUIRE(err->get_index().has_value() == true);
+    REQUIRE(err->get_index().value() == 1);
+
     seq.pop_back();
     REQUIRE(seq.size() == 1);
+    REQUIRE(seq.get_error().has_value());
+    REQUIRE(seq.get_error()->get_index().has_value() == false);
 
     seq.pop_back();
     REQUIRE(seq.size() == 0);

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -77,7 +77,7 @@ TEST_CASE("Sequence: assign()", "[Sequence]")
     seq.push_back(Step{Step::type_action});
     seq.push_back(Step{Step::type_action});
 
-    SECTION("assign step as lvalue (iterator)")
+    SECTION("assign step as lvalue")
     {
         Step step{Step::type_if};
         seq.assign(seq.begin()+1, step);
@@ -88,7 +88,7 @@ TEST_CASE("Sequence: assign()", "[Sequence]")
             REQUIRE(step.get_type() == expected[idx++]);
     }
 
-    SECTION("assign step as rvalue (iterator)")
+    SECTION("assign step as rvalue")
     {
         seq.assign(seq.begin()+1, Step{Step::type_if});
 
@@ -130,7 +130,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
     REQUIRE(err->get_index().has_value());
     REQUIRE(err->get_index().value() == 2);
 
-    SECTION("erase first (iterator)")
+    SECTION("erase first")
     {
         auto erase = seq.erase(seq.begin());
         REQUIRE(not seq.empty());
@@ -140,7 +140,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().value_or(-1) == 1);
     }
 
-    SECTION("erase middle (iterator)")
+    SECTION("erase middle")
     {
         auto erase = seq.erase(seq.begin()+2);
         REQUIRE(not seq.empty());
@@ -150,7 +150,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().has_value() == false);
     }
 
-    SECTION("erase last (iterator)")
+    SECTION("erase last")
     {
         auto erase = seq.erase(seq.end()-1);
         REQUIRE(not seq.empty());
@@ -160,7 +160,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().value_or(-1) == 2);
     }
 
-    SECTION("erase end (iterator)")
+    SECTION("erase end")
     {
         seq.erase(seq.end());
         REQUIRE(not seq.empty());
@@ -169,7 +169,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().value_or(-1) == 2);
     }
 
-    SECTION("erase range from beginning (iterator)")
+    SECTION("erase range from beginning")
     {
         auto erase = seq.erase(seq.begin(), seq.begin()+2);
         REQUIRE(not seq.empty());
@@ -179,7 +179,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().value_or(-1) == 0);
     }
 
-    SECTION("erase range from middle (iterator)")
+    SECTION("erase range from middle")
     {
         auto erase = seq.erase(seq.begin()+1, seq.begin()+3);
         REQUIRE(not seq.empty());
@@ -189,7 +189,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().has_value() == false);
     }
 
-    SECTION("erase range from end (iterator)")
+    SECTION("erase range from end")
     {
         auto erase = seq.erase(seq.end()-3, seq.end()-1);
         REQUIRE(not seq.empty());
@@ -199,7 +199,7 @@ TEST_CASE("Sequence: erase()", "[Sequence]")
         REQUIRE(seq.get_error()->get_index().has_value() == false);
     }
 
-    SECTION("erase range from end (iterator)")
+    SECTION("erase range from end")
     {
         auto erase = seq.erase(seq.end()-2, seq.end());
         REQUIRE(not seq.empty());


### PR DESCRIPTION
When a sequence fails, the Error object that can be obtained via `Sequence::get_error()` contains the index of the step that caused the error. This also shows up as a red indicator in the Taskomat GUI.

If a step is deleted or inserted before the error step or if the error step itself is deleted, the index is not updated. This means that the wrong step is now indicated in red.

This PR corrects this behavior via modifications to `Sequence::pop_back()`, `Sequence::insert()`, and `Sequence::erase()`.

Closes #102.