### PR TITLE
SequenceManager: Fix storing unmodified sequences

### DIFF
--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -204,11 +204,13 @@ public:
      * consecutive number followed by the type of the step and the extension `'.lua'`.
      * The step number is zero-filled to allow alphanumerical sorting
      * (e.g. `step_01_action.lua`).
-     * This function use git.
+     * This function uses git.
      *
      * \param sequence  the sequence to be stored
+     * \returns True if the sequence has been stored or false if it was unmodified
+     * \exception git::Error is thrown if git could not handle the operation
      */
-    void store_sequence(const Sequence& sequence);
+    bool store_sequence(const Sequence& sequence);
 
 private:
     /// Base path to the sequences.

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -338,14 +338,12 @@ void SequenceManager::rename_sequence(Sequence& sequence, const SequenceName& ne
     sequence.set_name(new_name);
 }
 
-void SequenceManager::store_sequence(const Sequence& seq)
+bool SequenceManager::store_sequence(const Sequence& seq)
 {
-    auto ok = perform_commit("Modify sequence ",
+    return perform_commit("Modify sequence ",
         [this, &seq]() {
             return this->write_sequence_to_disk(seq);
         });
-    if (not ok)
-        throw Error{ cat("Cannot commit sequence store ", to_string(seq.get_unique_id())) };
 }
 
 std::string SequenceManager::write_sequence_to_disk(const Sequence& seq)


### PR DESCRIPTION
[why]
When an unmodified Sequence is to be stored an error is thrown. It is hard (but not impossible) to distinguish a real failure from an attempt to "store" no change.

[how]
Do not throw on unmodified Sequences but instead return a boolean that indicates if changes did exist.
Git errors are still exceptions.
This makes the error handling much more easy.