### PR TITLE
Remove automatic renaming of legacy sequence folders

### DIFF
--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -117,18 +117,13 @@ public:
     std::filesystem::path get_path() const { return path_; }
 
     /**
-     * Return an unsorted list of all valid sequences that are found inside the base path
-     * and rename sequence folders that do not contain a valid unique ID.
+     * Return an unsorted list of all valid sequences that are found in the base path.
      *
-     * This function examines all folders inside the base path. If any of these folder
-     * names does not contain a valid unique ID, one is randomly generated and the folder
-     * is renamed accordingly.
+     * This function quietly ignores folders that do not follow the naming convention for
+     * sequences.
      *
      * \returns a vector containing one SequenceOnDisk object for each sequence that was
      *          found. The paths in the returned objects are relative to the base path.
-     *
-     * \exception Error is thrown if one of the folders needs to be renamed but the
-     *            renaming fails.
      */
     std::vector<SequenceOnDisk> list_sequences() const;
 

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -219,10 +219,10 @@ TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
     std::filesystem::create_directory(root / "some_weirdo_folder[x1234567890abcdef]");
 
     // create a sequence directory without a unique ID, but with a sequence.lua file
+    // (should be ignored)
     std::filesystem::create_directory(root / "A legacy sequence");
     std::fstream f2(root / "A legacy sequence/sequence.lua", std::ios::out);
     f2.close();
-
 
     SequenceManager sm{ root };
     auto sequences = sm.list_sequences();
@@ -232,22 +232,17 @@ TEST_CASE("SequenceManager: list_sequences()", "[SequenceManager]")
             return a.path < b.path;
         });
 
-    REQUIRE(sequences.size() == 3);
+    REQUIRE(sequences.size() == 2);
 
-    REQUIRE_THAT(sequences[0].path, StartsWith("A_legacy_sequence["));
+    REQUIRE_THAT(sequences[0].path, StartsWith("test.seq.1["));
     REQUIRE_THAT(sequences[0].path, EndsWith("]"));
-    REQUIRE(sequences[0].name == SequenceName{ "A_legacy_sequence" });
+    REQUIRE(sequences[0].name == SequenceName{ "test.seq.1" });
     REQUIRE(sequences[0].unique_id != 0_uid);
 
-    REQUIRE_THAT(sequences[1].path, StartsWith("test.seq.1["));
+    REQUIRE_THAT(sequences[1].path, StartsWith("test.seq.2["));
     REQUIRE_THAT(sequences[1].path, EndsWith("]"));
-    REQUIRE(sequences[1].name == SequenceName{ "test.seq.1" });
+    REQUIRE(sequences[1].name == SequenceName{ "test.seq.2" });
     REQUIRE(sequences[1].unique_id != 0_uid);
-
-    REQUIRE_THAT(sequences[2].path, StartsWith("test.seq.2["));
-    REQUIRE_THAT(sequences[2].path, EndsWith("]"));
-    REQUIRE(sequences[2].name == SequenceName{ "test.seq.2" });
-    REQUIRE(sequences[2].unique_id != 0_uid);
 }
 
 TEST_CASE("SequenceManager: load_sequence() - Nonexistent unique ID", "[SequenceManager]")


### PR DESCRIPTION
This PR removes the automatic renaming of legacy sequence folders (which should never have been in the code according to @Finii :) ). All installations (that we know of) have already moved to the new folder format, so this should not have any impact.