### PR TITLE
Add load_lua_script(), build forgotten tests

### DIFF
--- a/include/taskolib/execute_lua_script.h
+++ b/include/taskolib/execute_lua_script.h
@@ -2,9 +2,9 @@
  * \file   execute_lua_script.h
  * \author Lars Fröhlich
  * \date   Created on November 15, 2022
- * \brief  Declaration of execute_lua_script().
+ * \brief  Declaration of execute_lua_script() and load_lua_script().
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -28,6 +28,8 @@
 #include <string>
 #include <variant>
 
+#include <gul14/expected.h>
+
 #include "sol/sol.hpp"
 
 namespace task {
@@ -45,6 +47,20 @@ namespace task {
  */
 std::variant<sol::object, std::string>
 execute_lua_script(sol::state& lua, sol::string_view script);
+
+/**
+ * Load a Lua script into the given Lua state and check its syntax without running it.
+ *
+ * \returns a sol::load_result proxy object that can be called to run the script or cast
+ *          to a sol::function/sol::protected_function. If the syntax check failed, a
+ *          string with an error message is returned instead. This error message is
+ *          pre-processed to a certain degree: Unhelpful parts like the chunk name of the
+ *          script (`[string "..."]:`) are removed, and a few known special messages are
+ *          replaced by more readable explanations.
+ */
+gul14::expected<sol::load_result, std::string>
+load_lua_script(sol::state& lua, sol::string_view script);
+
 
 } // namespace task
 

--- a/src/execute_lua_script.cc
+++ b/src/execute_lua_script.cc
@@ -2,7 +2,7 @@
  * \file   execute_lua_script.cc
  * \author Lars Fröhlich, Marcus Walla
  * \date   Created on November 15, 2022
- * \brief  Implementation of execute_lua_script().
+ * \brief  Implementation of execute_lua_script() and load_lua_script().
  *
  * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -32,34 +32,38 @@
 
 namespace task {
 
+namespace {
+
+const std::string anchor = u8"\u2693";
+constexpr gul14::string_view chunk_prefix{ u8"[string \"\u2693\"]:" };
+
+std::string process_msg(gul14::string_view msg)
+{
+    // If C++ code is called by Lua and throws an exception that is not derived
+    // from std::exception, the exception is not intercepted by the Sol
+    // trampoline, but caught directly by Lua. Lua would expect this exception
+    // to come from lua_error() and therefore looks for an error message on its
+    // stack, which is not there. Depending on build type and Sol2 configuration,
+    // this can generate a stack error message or not. We try to convert this into
+    // a concise error message.
+    if (msg.empty() ||
+        msg == "lua: error: stack index 1, expected string, received function")
+    {
+        return "Unknown exception";
+    }
+
+    return gul14::replace(msg, chunk_prefix, "");
+}
+
+} // anonymous namespace
+
 std::variant<sol::object, std::string>
 execute_lua_script(sol::state& lua, sol::string_view script)
 {
-    const std::string anchor = u8"\u2693";
-    constexpr gul14::string_view chunk_prefix{ u8"[string \"\u2693\"]:" };
-
-    auto process_msg =
-        [chunk_prefix](gul14::string_view msg) -> std::string
-        {
-            // If C++ code is called by Lua and throws an exception that is not derived
-            // from std::exception, the exception is not intercepted by the Sol
-            // trampoline, but caught directly by Lua. Lua would expect this exception
-            // to come from lua_error() and therefore looks for an error message on its
-            // stack, which is not there. Depending on build type and Sol2 configuration,
-            // this can generate a stack error message or not. We try to convert this into
-            // a concise error message.
-            if (msg.empty() ||
-                msg == "lua: error: stack index 1, expected string, received function")
-            {
-                return "Unknown exception";
-            }
-
-            return gul14::replace(msg, chunk_prefix, "");
-        };
-
     try
     {
-        auto protected_result = lua.safe_script(script, sol::script_pass_on_error, anchor);
+        auto protected_result = lua.safe_script(
+            script, sol::script_pass_on_error, anchor);
 
         if (!protected_result.valid())
         {
@@ -77,6 +81,16 @@ execute_lua_script(sol::state& lua, sol::string_view script)
     {
         return std::string{ "Unknown C++ exception" };
     }
+}
+
+gul14::expected<sol::load_result, std::string>
+load_lua_script(sol::state& lua, sol::string_view script)
+{
+    sol::load_result result = lua.load(script, anchor);
+    if (result.valid())
+        return result;
+
+    return gul14::unexpected(static_cast<sol::error>(result).what());
 }
 
 } // namespace task

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@ test_src = files(
     'test_Context.cc',
     'test_deserialize_sequence.cc',
     'test_exceptions.cc',
+    'test_execute_lua_script.cc',
     'test_Executor.cc',
     'test_internals.cc',
     'test_LockedQueue.cc',

--- a/tests/test_execute_lua_script.cc
+++ b/tests/test_execute_lua_script.cc
@@ -32,8 +32,25 @@ using namespace std::literals;
 using namespace task;
 using namespace Catch::Matchers;
 
+TEST_CASE("load_lua_script()", "[execute_lua_script]")
+{
+    sol::state lua;
+
+    auto result = load_lua_script(lua, "return 42");
+    REQUIRE(result.has_value());
+    int function_call_result = (*result)();
+    REQUIRE(function_call_result == 42);
+
+    REQUIRE(load_lua_script(lua, "a = b").has_value());
+    REQUIRE(load_lua_script(lua, "a = unknown.variable").has_value());
+    REQUIRE(load_lua_script(lua, "a = 'asf").error() != "");
+    REQUIRE(load_lua_script(lua, "a = asf'").error() != "");
+    REQUIRE(load_lua_script(lua, "a = = 2").error() != "");
+    REQUIRE(load_lua_script(lua, "Hello world!").error() != "");
+}
+
 TEST_CASE("execute_lua_script(): Return values from simple scripts without errors",
-    "[lua_details]")
+    "[execute_lua_script]")
 {
     sol::state lua;
 
@@ -94,7 +111,7 @@ TEST_CASE("execute_lua_script(): Return values from simple scripts without error
     }
 }
 
-TEST_CASE("execute_lua_script(): Lua exceptions", "[lua_details]")
+TEST_CASE("execute_lua_script(): Lua exceptions", "[execute_lua_script]")
 {
     sol::state lua;
     open_safe_library_subset(lua); // for error() and pcall()
@@ -142,7 +159,7 @@ TEST_CASE("execute_lua_script(): Lua exceptions", "[lua_details]")
     }
 }
 
-TEST_CASE("execute_lua_script(): C++ exceptions", "[Step]")
+TEST_CASE("execute_lua_script(): C++ exceptions", "[execute_lua_script]")
 {
     sol::state lua;
     open_safe_library_subset(lua); // for error() and pcall()
@@ -196,21 +213,4 @@ TEST_CASE("execute_lua_script(): C++ exceptions", "[Step]")
         REQUIRE(result != nullptr);
         REQUIRE(result->as<int>() == 42);
     }
-}
-
-TEST_CASE("load_lua_script()", "[lua_details]")
-{
-    sol::state lua;
-
-    auto result = load_lua_script(lua, "return 42");
-    REQUIRE(result.has_value());
-    int function_call_result = (*result)();
-    REQUIRE(function_call_result == 42);
-
-    REQUIRE(load_lua_script(lua, "a = b").has_value());
-    REQUIRE(load_lua_script(lua, "a = unknown.variable").has_value());
-    REQUIRE(load_lua_script(lua, "a = 'asf").error() != "");
-    REQUIRE(load_lua_script(lua, "a = asf'").error() != "");
-    REQUIRE(load_lua_script(lua, "a = = 2").error() != "");
-    REQUIRE(load_lua_script(lua, "Hello world!").error() != "");
 }

--- a/tests/test_execute_lua_script.cc
+++ b/tests/test_execute_lua_script.cc
@@ -4,7 +4,7 @@
  * \date   Created on October 28, 2022
  * \brief  Test suite for Lua-related internal functions.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,7 +25,8 @@
 #include <gul14/catch.h>
 #include <gul14/time_util.h>
 
-#include "taskomat/execute_lua_script.h"
+#include "lua_details.h"
+#include "taskolib/execute_lua_script.h"
 
 using namespace std::literals;
 using namespace task;
@@ -195,4 +196,21 @@ TEST_CASE("execute_lua_script(): C++ exceptions", "[Step]")
         REQUIRE(result != nullptr);
         REQUIRE(result->as<int>() == 42);
     }
+}
+
+TEST_CASE("load_lua_script()", "[lua_details]")
+{
+    sol::state lua;
+
+    auto result = load_lua_script(lua, "return 42");
+    REQUIRE(result.has_value());
+    int function_call_result = (*result)();
+    REQUIRE(function_call_result == 42);
+
+    REQUIRE(load_lua_script(lua, "a = b").has_value());
+    REQUIRE(load_lua_script(lua, "a = unknown.variable").has_value());
+    REQUIRE(load_lua_script(lua, "a = 'asf").error() != "");
+    REQUIRE(load_lua_script(lua, "a = asf'").error() != "");
+    REQUIRE(load_lua_script(lua, "a = = 2").error() != "");
+    REQUIRE(load_lua_script(lua, "Hello world!").error() != "");
 }


### PR DESCRIPTION
This PR adds a simple free function `load_lua_script()` to check the syntax of a piece of Lua script. This would make it possible to emit a warning if someone presses "Save" on the Taskomat panel and has a syntax error in their code.
    
There are many possible improvements amd variations here:
- The file name is no longer good. `execute_lua_script.cc` now contains a function called `check_lua_script()` as well. Should we rename?
- The function could create a temporary `sol::state` just to load the script. This would guarantee total isolation at the cost of some more expensive initialization. I do not think there is a bad side effect of calling load repeatedly on some Lua state, but I am also not sure.

As a drive-by fix, this PR also makes sure that the unit tests from `test_execute_lua_script.cc` are actually built and run. They were forgotten before.