### PR TITLE
Make execute_lua_script() return expected instead of variant

### DIFF
--- a/include/taskolib/execute_lua_script.h
+++ b/include/taskolib/execute_lua_script.h
@@ -26,7 +26,6 @@
 #define TASKOLIB_EXECUTE_LUA_SCRIPT_H_
 
 #include <string>
-#include <variant>
 
 #include <gul14/expected.h>
 
@@ -38,25 +37,26 @@ namespace task {
  * Execute a Lua script safely, intercepting all possible exceptions that may occur during
  * its execution.
  *
- * This function returns a variant: If the Lua script finishes without error, it contains
- * a sol::object representing the return value of the script. If a Lua error or C++
- * exception occurs, the variant contains a string with an error message. The error
- * message is pre-processed to a certain degree: Unhelpful parts like the chunk name of
- * the script (`[string "..."]:`) are removed, and a few known special messages are
+ * This function returns a gul14::expected object: If the Lua script finishes without
+ * error, it contains a sol::object representing the return value of the script. If a Lua
+ * error or C++ exception occurs, the variant contains a string with an error message. The
+ * error message is pre-processed to a certain degree: Unhelpful parts like the chunk name
+ * of the script (`[string "..."]:`) are removed, and a few known special messages are
  * replaced by more readable explanations.
  */
-std::variant<sol::object, std::string>
+gul14::expected<sol::object, std::string>
 execute_lua_script(sol::state& lua, sol::string_view script);
 
 /**
  * Load a Lua script into the given Lua state and check its syntax without running it.
  *
- * \returns a sol::load_result proxy object that can be called to run the script or cast
- *          to a sol::function/sol::protected_function. If the syntax check failed, a
- *          string with an error message is returned instead. This error message is
- *          pre-processed to a certain degree: Unhelpful parts like the chunk name of the
- *          script (`[string "..."]:`) are removed, and a few known special messages are
- *          replaced by more readable explanations.
+ * This function returns a gul14::expected object: If the syntax of the Lua script is OK,
+ * it contains a sol::load_result proxy object that can be called to run the script or
+ * cast to a sol::function/sol::protected_function. If the syntax check fails, a string
+ * with an error message is returned instead. This error message is pre-processed to a
+ * certain degree: Unhelpful parts like the chunk name of the script (`[string "..."]:`)
+ * are removed, and a few known special messages are replaced by more readable
+ * explanations.
  */
 gul14::expected<sol::load_result, std::string>
 load_lua_script(sol::state& lua, sol::string_view script);

--- a/include/taskolib/execute_lua_script.h
+++ b/include/taskolib/execute_lua_script.h
@@ -39,7 +39,7 @@ namespace task {
  *
  * This function returns a gul14::expected object: If the Lua script finishes without
  * error, it contains a sol::object representing the return value of the script. If a Lua
- * error or C++ exception occurs, the variant contains a string with an error message. The
+ * error or C++ exception occurs, the returned object contains a string with an error message. The
  * error message is pre-processed to a certain degree: Unhelpful parts like the chunk name
  * of the script (`[string "..."]:`) are removed, and a few known special messages are
  * replaced by more readable explanations.

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -1,10 +1,10 @@
 /**
- * \file   Step.cc
- * \author Lars Fröhlich, Marcus Walla
- * \date   Created on December 7, 2021
- * \brief  Implementation of the Step class.
+ * \file    Step.cc
+ * \authors Lars Fröhlich, Marcus Walla
+ * \date    Created on December 7, 2021
+ * \brief   Implementation of the Step class.
  *
- * \copyright Copyright 2021-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -128,19 +128,19 @@ bool Step::execute_impl(Context& context, CommChannel* comm,
 
     if (executes_script(get_type()) and not context.step_setup_script.empty())
     {
-        const auto result_or_error = execute_lua_script(lua, context.step_setup_script);
-        if (std::holds_alternative<std::string>(result_or_error))
-            throw Error(gul14::cat("[setup] ",std::get<std::string>(result_or_error)));
+        const auto result = execute_lua_script(lua, context.step_setup_script);
+        if (not result.has_value())
+            throw Error(gul14::cat("[setup] ", result.error()));
     }
 
     copy_used_variables_from_context_to_lua(context, lua);
-    const auto result_or_error = execute_lua_script(lua, get_script());
+    const auto result = execute_lua_script(lua, get_script());
     copy_used_variables_from_lua_to_context(lua, context);
 
-    if (std::holds_alternative<std::string>(result_or_error))
-        throw Error(std::get<std::string>(result_or_error));
+    if (not result.has_value())
+        throw Error(result.error());
 
-    const auto& obj = std::get<sol::object>(result_or_error);
+    const auto& obj = result.value();
 
     if (requires_bool_return_value(get_type()))
     {

--- a/src/execute_lua_script.cc
+++ b/src/execute_lua_script.cc
@@ -57,7 +57,7 @@ std::string process_msg(gul14::string_view msg)
 
 } // anonymous namespace
 
-std::variant<sol::object, std::string>
+gul14::expected<sol::object, std::string>
 execute_lua_script(sol::state& lua, sol::string_view script)
 {
     try
@@ -68,18 +68,18 @@ execute_lua_script(sol::state& lua, sol::string_view script)
         if (!protected_result.valid())
         {
             sol::error err = protected_result;
-            return process_msg(err.what());
+            return gul14::unexpected(process_msg(err.what()));
         }
 
         return static_cast<sol::object>(protected_result);
     }
     catch(const std::exception& e)
     {
-        return process_msg(e.what());
+        return gul14::unexpected(process_msg(e.what()));
     }
     catch(...)
     {
-        return std::string{ "Unknown C++ exception" };
+        return gul14::unexpected("Unknown C++ exception");
     }
 }
 

--- a/tests/test_execute_lua_script.cc
+++ b/tests/test_execute_lua_script.cc
@@ -56,57 +56,50 @@ TEST_CASE("execute_lua_script(): Return values from simple scripts without error
 
     SECTION("Empty script")
     {
-        auto result_or_error = execute_lua_script(lua, "");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "");
+        REQUIRE(result.has_value());
         REQUIRE(*result == sol::nil);
     }
 
     SECTION("return nil")
     {
-        auto result_or_error = execute_lua_script(lua, "return nil");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "return nil");
+        REQUIRE(result.has_value());
         REQUIRE(*result == sol::nil);
     }
 
     SECTION("return true")
     {
-        auto result_or_error = execute_lua_script(lua, "return true");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "return true");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<bool>() == true);
     }
 
     SECTION("return false")
     {
-        auto result_or_error = execute_lua_script(lua, "return false");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "return false");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<bool>() == false);
     }
 
     SECTION("return 42")
     {
-        auto result_or_error = execute_lua_script(lua, "return 42");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "return 42");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<int>() == 42);
     }
 
     SECTION("return 4.2")
     {
-        auto result_or_error = execute_lua_script(lua, "return 4.2");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "return 4.2");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<double>() == 4.2);
     }
 
     SECTION("return 'pippo'")
     {
-        auto result_or_error = execute_lua_script(lua, "return 'pippo'");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "return 'pippo'");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<std::string>() == "pippo");
     }
 }
@@ -118,10 +111,9 @@ TEST_CASE("execute_lua_script(): Lua exceptions", "[execute_lua_script]")
 
     SECTION("Syntax error")
     {
-        auto result_or_error = execute_lua_script(lua, "not a lua program");
-        auto* msg = std::get_if<std::string>(&result_or_error);
-        REQUIRE(msg != nullptr);
-        REQUIRE(*msg == "1: unexpected symbol near 'not'");
+        auto result = execute_lua_script(lua, "not a lua program");
+        REQUIRE(result.has_value() == false);
+        REQUIRE(result.error() == "1: unexpected symbol near 'not'");
         // This test is somewhat brittle against changes of Lua syntax error messages.
         // This is intentional: We should realize early if a new Lua version introduces
         // weird output and decide if we need to pre-process it for our users.
@@ -129,11 +121,10 @@ TEST_CASE("execute_lua_script(): Lua exceptions", "[execute_lua_script]")
 
     SECTION("Runtime error with message")
     {
-        auto result_or_error = execute_lua_script(
+        auto result = execute_lua_script(
             lua, "function boom(); error('mindful' .. 'ness', 0); end; boom()");
-        auto* msg = std::get_if<std::string>(&result_or_error);
-        REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, StartsWith("mindfulness"));
+        REQUIRE(result.has_value() == false);
+        REQUIRE_THAT(result.error(), StartsWith("mindfulness"));
         // Lua adds a stack trace after this output. This is a somewhat brittle test,
         // but since we have control over our Lua version, we are sure to spot it if
         // the output format changes.
@@ -141,20 +132,18 @@ TEST_CASE("execute_lua_script(): Lua exceptions", "[execute_lua_script]")
 
     SECTION("Runtime error without message")
     {
-        auto result_or_error = execute_lua_script(
+        auto result = execute_lua_script(
             lua, "function boom(); error('', 0); end; boom()");
-        auto* msg = std::get_if<std::string>(&result_or_error);
-        REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, not Contains("Unknown"));
-        REQUIRE_THAT(*msg, not Contains("exception"));
+        REQUIRE(result.has_value() == false);
+        REQUIRE_THAT(result.error(), not Contains("Unknown"));
+        REQUIRE_THAT(result.error(), not Contains("exception"));
     }
 
     SECTION("Runtime error, caught by pcall()")
     {
-        auto result_or_error = execute_lua_script(
+        auto result = execute_lua_script(
             lua, "function boom(); b = nil; b(); end; pcall(boom); return 42");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        REQUIRE(result.has_value());
         REQUIRE(result->as<int>() == 42);
     }
 }
@@ -170,47 +159,37 @@ TEST_CASE("execute_lua_script(): C++ exceptions", "[execute_lua_script]")
 
     SECTION("C++ standard exception with message")
     {
-        auto result_or_error = execute_lua_script(
-            lua, "throw_logic_error_with_msg()");
-        auto* msg = std::get_if<std::string>(&result_or_error);
-        REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, StartsWith("red rabbit"));
+        auto result = execute_lua_script(lua, "throw_logic_error_with_msg()");
+        REQUIRE(result.has_value() == false);
+        REQUIRE_THAT(result.error(), StartsWith("red rabbit"));
     }
 
     SECTION("C++ standard exception without message")
     {
-        auto result_or_error = execute_lua_script(
-            lua, "throw_logic_error_without_msg()");
-        auto* msg = std::get_if<std::string>(&result_or_error);
-        REQUIRE(msg != nullptr);
-        REQUIRE_THAT(*msg, not Contains("Unknown"));
-        REQUIRE_THAT(*msg, not Contains("exception"));
+        auto result = execute_lua_script(lua, "throw_logic_error_without_msg()");
+        REQUIRE(result.has_value() == false);
+        REQUIRE_THAT(result.error(), not Contains("Unknown"));
+        REQUIRE_THAT(result.error(), not Contains("exception"));
     }
 
     SECTION("Nonstandard C++ exceptions are reported as errors")
     {
-        auto result_or_error = execute_lua_script(
-            lua, "throw_weird_exception()");
-        auto* msg = std::get_if<std::string>(&result_or_error);
-        REQUIRE(msg != nullptr);
-        REQUIRE(*msg == "Unknown exception");
+        auto result = execute_lua_script(lua, "throw_weird_exception()");
+        REQUIRE(result.has_value() == false);
+        REQUIRE(result.error() == "Unknown exception");
     }
 
     SECTION("Standard C++ exceptions are converted to Lua errors and caught by pcall()")
     {
-        auto result_or_error = execute_lua_script(
-            lua, "pcall(throw_logic_error); return 42");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "pcall(throw_logic_error); return 42");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<int>() == 42);
     }
 
     SECTION("Nonstandard C++ exceptions are converted to Lua errors and caught by pcall()")
     {
-        auto result_or_error = execute_lua_script(
-            lua, "pcall(throw_weird_error); return 42");
-        auto* result = std::get_if<sol::object>(&result_or_error);
-        REQUIRE(result != nullptr);
+        auto result = execute_lua_script(lua, "pcall(throw_weird_error); return 42");
+        REQUIRE(result.has_value());
         REQUIRE(result->as<int>() == 42);
     }
 }


### PR DESCRIPTION
Due to the lack of an `expected` type in C++17, the function was implemented as returning a variant. Unfortunately, dealing with variants is somewhat clumsy and does not convey the intent of having an expected outcome and an error outcome.

Since we have introduced `gul14::expected` in the meantime, we can just use it as the return type. The unit tests show how this simplifies the calling code.