### PR TITLE
Import sequence from file system path

### DIFF
--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -29,13 +29,12 @@
 #include <string>
 #include <vector>
 
+#include <gul14/optional.h>
 #include <gul14/string_view.h>
-#include <gul14/SmallVector.h>
 #include <libgit4cpp/Repository.h>
 
 #include "taskolib/Sequence.h"
 #include "taskolib/UniqueId.h"
-
 
 namespace task {
 
@@ -67,6 +66,16 @@ public:
         std::filesystem::path path; ///< Path to the sequence, relative to SequenceManager base path
         SequenceName name; ///< Machine-friendly name of the sequence
         UniqueId unique_id; ///< Unique ID of the sequence
+
+        friend bool operator==(const SequenceOnDisk& a, const SequenceOnDisk& b) noexcept
+        {
+            return a.unique_id == b.unique_id && a.name == b.name && a.path == b.path;
+        }
+
+        friend bool operator!=(const SequenceOnDisk& a, const SequenceOnDisk& b) noexcept
+        {
+            return !(a == b);
+        }
     };
 
     /**
@@ -148,6 +157,17 @@ public:
      */
     Sequence
     load_sequence(UniqueId uid, const std::vector<SequenceOnDisk>& sequences) const;
+
+    /**
+     * Determine the name and unique ID of a sequence from a folder name, if possible.
+     *
+     * Taskolib stores sequences in a folder following the scheme "name[uid]". This
+     * function extracts the final folder name from the given path and splits it into name
+     * and unique ID. If the folder does not follow the naming scheme, nullopt is
+     * returned.
+     */
+    static gul14::optional<SequenceOnDisk>
+    parse_folder_name(const std::filesystem::path& folder);
 
     /**
      * Remove a sequence from the base folder.

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -129,6 +129,22 @@ public:
     std::filesystem::path get_path() const { return path_; }
 
     /**
+     * Import a sequence from a folder, assigning a new unique ID to it.
+     *
+     * This function loads an existing sequence from the specified path. If the import is
+     * successful, the new sequence is stored in the base folder. It keeps the name and
+     * label of the original, but a random unique ID is assigned.
+     *
+     * \param path  Path to the original sequence folder
+     *
+     * \returns the copied sequence as if it had been loaded from disk.
+     *
+     * \exception Error is thrown if the original sequence cannot be loaded or if the new
+     *            sequence folder cannot be created.
+     */
+    Sequence import_sequence(const std::filesystem::path& path);
+
+    /**
      * Return an unsorted list of all valid sequences that are found in the base path.
      *
      * This function quietly ignores folders that do not follow the naming convention for

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -63,7 +63,10 @@ public:
     /// A struct to represent a sequence on disk.
     struct SequenceOnDisk
     {
-        std::filesystem::path path; ///< Path to the sequence, relative to SequenceManager base path
+        /// Path to the sequence (usually relative to SequenceManager base path, but can
+        /// also be absolute)
+        std::filesystem::path path;
+
         SequenceName name; ///< Machine-friendly name of the sequence
         UniqueId unique_id; ///< Unique ID of the sequence
 
@@ -159,6 +162,19 @@ public:
     load_sequence(UniqueId uid, const std::vector<SequenceOnDisk>& sequences) const;
 
     /**
+     * Load a sequence from an arbitrary folder on disk.
+     *
+     * This function can be used to load a sequence from a folder that is not managed by
+     * the SequenceManager. The machine-friendly name and unique ID of the sequence are
+     * parsed from its folder name.
+     *
+     * \param folder  The sequence folder to be loaded
+     *
+     * \exception Error is thrown if the sequence cannot be loaded.
+     */
+    Sequence load_sequence(std::filesystem::path folder) const;
+
+    /**
      * Determine the name and unique ID of a sequence from a folder name, if possible.
      *
      * Taskolib stores sequences in a folder following the scheme "name[uid]". This
@@ -241,6 +257,9 @@ private:
      * \exception Error is thrown if no unique ID can be found.
      */
     static UniqueId create_unique_id(const std::vector<SequenceOnDisk>& sequences);
+
+    /// Load a sequence from the specified path, with the given name and unique ID.
+    Sequence load_sequence(const SequenceOnDisk& seq_on_disk) const;
 
     /**
      * Perform changes and commit them to the git repository.

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -206,6 +206,23 @@ SequenceManager::find_sequence_on_disk(UniqueId uid,
     return *it;
 }
 
+Sequence SequenceManager::import_sequence(const std::filesystem::path& path)
+{
+    auto seq = load_sequence(path);
+
+    const UniqueId new_unique_id = create_unique_id(list_sequences());
+    seq.set_unique_id(new_unique_id);
+
+    auto ok = perform_commit(gul14::cat("Import sequence from ", path.string(), " to "),
+        [this, &seq]() {
+            return this->write_sequence_to_disk(seq);
+        });
+    if (not ok)
+        throw Error{ cat("Cannot commit imported sequence ", to_string(new_unique_id)) };
+
+    return seq;
+}
+
 std::vector<SequenceManager::SequenceOnDisk> SequenceManager::list_sequences() const
 {
     std::vector<SequenceOnDisk> sequences;

--- a/src/deserialize_sequence.h
+++ b/src/deserialize_sequence.h
@@ -4,7 +4,7 @@
  * \date   Created on May 24, 2022
  * \brief  Deserialize Sequence and Steps from storage hardware.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -28,42 +28,10 @@
 #include <filesystem>
 #include <iostream>
 
-#include <gul14/optional.h>
-
 #include "taskolib/Sequence.h"
-#include "taskolib/SequenceName.h"
 #include "taskolib/Step.h"
-#include "taskolib/UniqueId.h"
 
 namespace task {
-
-struct SequenceInfo
-{
-    std::string label;
-    gul14::optional<SequenceName> name;
-    gul14::optional<UniqueId> unique_id;
-
-    friend bool operator==(const SequenceInfo& a, const SequenceInfo& b) noexcept
-    {
-        return a.unique_id == b.unique_id && a.label == b.label;
-    }
-
-    friend bool operator!=(const SequenceInfo& a, const SequenceInfo& b) noexcept
-    {
-        return !(a == b);
-    }
-};
-
-/**
- * Determine the label, name, and unique ID of a sequence from a filename, if possible.
- *
- * New versions of Taskolib store sequences in a folder following the scheme "name[uid]",
- * whereas old versions just used an escaped form of the label as the folder name. This
- * function looks for the angle brackets to figure out which of the two formats is used.
- *
- * This is the reverse function to make_sequence_filename().
- */
-SequenceInfo get_sequence_info_from_filename(gul14::string_view filename);
 
 /**
  * Deserialize parameters of Step from the input stream.

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -259,6 +259,18 @@ TEST_CASE("SequenceManager: load_sequence() - Nonexistent unique ID", "[Sequence
     REQUIRE_THROWS_AS(manager.load_sequence(UniqueId{ }), Error);
 }
 
+TEST_CASE("parse_folder_name()", "[SequenceManager]")
+{
+    REQUIRE(SequenceManager::parse_folder_name("my_sequence[deadbeef]")
+        == SequenceManager::SequenceOnDisk{
+            "my_sequence[deadbeef]", SequenceName{ "my_sequence" }, 0xdeadbeef_uid });
+    REQUIRE(SequenceManager::parse_folder_name("[1234567890abcdef]")
+        == SequenceManager::SequenceOnDisk{
+            "[1234567890abcdef]", SequenceName{ "" }, 0x1234567890abcdef_uid });
+    REQUIRE(SequenceManager::parse_folder_name("A$2f$22sequence$22$24$3cagain$3e [my_uid]")
+        == gul14::nullopt);
+}
+
 TEST_CASE("SequenceManager: remove_sequence()", "[SequenceManager]")
 {
     const auto dir = temp_dir / "remove_sequence_test";

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 26, 2023
  * \brief  Test suite for free functions declared in deserialize_sequence.h.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -28,13 +28,3 @@
 
 using namespace task;
 using namespace task::literals;
-
-TEST_CASE("get_sequence_info_from_filename()", "[deserialize_sequence]")
-{
-    REQUIRE(get_sequence_info_from_filename("my_sequence[deadbeef]")
-        == SequenceInfo{ "", SequenceName{ "my_sequence" }, 0xdeadbeef_uid });
-    REQUIRE(get_sequence_info_from_filename("[1234567890abcdef]")
-        == SequenceInfo{ "", gul14::nullopt, 0x1234567890abcdef_uid });
-    REQUIRE(get_sequence_info_from_filename("A$2f$22sequence$22$24$3cagain$3e [my_uid]")
-        == SequenceInfo{ "A/\"sequence\"$<again> [my_uid]", gul14::nullopt, gul14::nullopt });
-}


### PR DESCRIPTION
This PR adds a `SequenceManager::import_sequence()` member function that can import a sequence from an arbitrary file system path. Some of the underlying infrastructure is cleaned up and adapted in the process.