### PR TITLE
Add tags to categorize sequences

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -15,6 +15,7 @@ public_headers = [
    'taskolib/SequenceName.h',
    'taskolib/Step.h',
    'taskolib/StepIndex.h',
+   'taskolib/Tag.h',
    'taskolib/taskolib.h',
    'taskolib/time_types.h',
    'taskolib/Timeout.h',

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -146,6 +146,15 @@ namespace task {
  * The sequence stores the timestamp of when it was last executed.
  *
  * \see get_time_of_last_execution()
+ *
+ * ### Tags
+ *
+ * An arbitrary number of tags can be associated with a sequence. Tags are used to
+ * categorize sequences and to make them easier to find. Tags are small pieces of text
+ * that may contain only the lowercase letters a-z, digits, or the hyphen ("-"). Their
+ * length can range from 1 to 32 characters. Tags are stored in alphabetical order.
+ *
+ * \see get_tags(), set_tags()
  */
 class Sequence
 {

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -46,6 +46,7 @@
 #include "taskolib/SequenceName.h"
 #include "taskolib/Step.h"
 #include "taskolib/StepIndex.h"
+#include "taskolib/Tag.h"
 #include "taskolib/TimeoutTrigger.h"
 #include "taskolib/UniqueId.h"
 
@@ -402,7 +403,10 @@ public:
      *
      * \returns the step setup script.
      */
-    const std::string& get_step_setup_script() const noexcept{ return step_setup_script_; }
+    const std::string& get_step_setup_script() const noexcept { return step_setup_script_; }
+
+    /// Return the tags associated with this sequence.
+    const std::vector<Tag>& get_tags() const noexcept { return tags_; }
 
     /**
      * Returns time of last execution. It returns TimePoint{} on a fresh created sequence.
@@ -691,15 +695,15 @@ private:
     /// Empty if indentation is correct and complete, error message otherwise
     std::string indentation_error_;
 
-    UniqueId unique_id_; ///< Unique ID.
-    SequenceName name_; ///< Machine-readable name.
-    std::string label_; ///< Human-readable sequence label.
-    std::string maintainers_; ///< One or more maintainers.
+    UniqueId unique_id_;            ///< Unique ID.
+    SequenceName name_;             ///< Machine-readable name.
+    std::string label_;             ///< Human-readable sequence label.
+    std::string maintainers_;       ///< One or more maintainers.
     std::string step_setup_script_; ///< Step setup script.
+    std::vector<Tag> tags_;         ///< Tags for categorizing the sequence.
+    std::vector<Step> steps_;       ///< Collection of steps.
 
-    std::vector<Step> steps_; ///< Collection of steps.
-
-    bool is_running_{false}; ///< Flag to determine if the sequence is running.
+    bool is_running_{ false }; ///< Flag to determine if the sequence is running.
 
     TimeoutTrigger timeout_trigger_; ///< Logic to check for elapsed sequence timeout.
 

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -405,7 +405,7 @@ public:
      */
     const std::string& get_step_setup_script() const noexcept { return step_setup_script_; }
 
-    /// Return the tags associated with this sequence.
+    /// Return the tags associated with this sequence in alphabetical order.
     const std::vector<Tag>& get_tags() const noexcept { return tags_; }
 
     /**
@@ -670,6 +670,13 @@ public:
      * \exception Error is thrown if the sequence is currently running.
      */
     void set_step_setup_script(gul14::string_view step_setup_script);
+
+    /**
+     * Set the tags associated with this sequence.
+     *
+     * Duplicate tags are removed silently.
+     */
+    void set_tags(const std::vector<Tag>& tags);
 
     /// Set the timeout duration for executing the sequence.
     void set_timeout(Timeout timeout) { timeout_trigger_.set_timeout(timeout); }

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -386,41 +386,25 @@ public:
      */
     const std::string& get_indentation_error() const noexcept { return indentation_error_; }
 
-    /**
-     * Return the human-readable sequence label.
-     *
-     * @returns a descriptive name for the sequence.
-     */
+    /// Return the human-readable sequence label.
     const std::string& get_label() const noexcept { return label_; }
 
-    /**
-     * Return the maintainers of the sequence.
-     *
-     * \returns the maintainers of the sequence.
-     */
+    /// Return a string listing the maintainer(s) of the sequence.
     const std::string& get_maintainers() const noexcept { return maintainers_; }
 
-    /**
-     * Return the machine-friendly name of the sequence.
-     *
-     * \returns the unique ID.
-     */
+    /// Return the machine-friendly name of the sequence.
     const SequenceName& get_name() const noexcept { return name_; }
 
-    /**
-     * Get the step setup script.
-     *
-     * \returns the step setup script.
-     */
+    /// Return the step setup script.
     const std::string& get_step_setup_script() const noexcept { return step_setup_script_; }
 
     /// Return the tags associated with this sequence in alphabetical order.
     const std::vector<Tag>& get_tags() const noexcept { return tags_; }
 
     /**
-     * Returns time of last execution. It returns TimePoint{} on a fresh created sequence.
+     * Determine when the sequence was last executed.
      *
-     * \returns time of the last execution.
+     * For a sequence that was never run, TimePoint{} is returned.
      */
     TimePoint get_time_of_last_execution() const
     {
@@ -430,11 +414,7 @@ public:
     /// Return the timeout duration for executing the sequence.
     Timeout get_timeout() const { return timeout_trigger_.get_timeout(); }
 
-    /**
-     * Return the unique ID of the sequence.
-     *
-     * \returns the unique ID.
-     */
+    /// Return the unique ID of the sequence.
     UniqueId get_unique_id() const noexcept { return unique_id_; }
 
     /**

--- a/include/taskolib/Tag.h
+++ b/include/taskolib/Tag.h
@@ -28,7 +28,6 @@
 #include <iosfwd>
 #include <string>
 
-#include <gul14/optional.h>
 #include <gul14/string_view.h>
 
 namespace task {
@@ -64,14 +63,6 @@ public:
      *            characters.
      */
     explicit Tag(gul14::string_view name);
-
-    /**
-     * Create a Tag from the given string, returning an empty optional if the string
-     * violates length or character constraints.
-     *
-     * The uppercase ASCII characters A-Z are automatically converted to lowercase.
-     */
-    static gul14::optional<Tag> from_string(gul14::string_view name);
 
     /// Determine if two tags are equal.
     friend bool operator==(const Tag& a, const Tag& b)

--- a/include/taskolib/Tag.h
+++ b/include/taskolib/Tag.h
@@ -1,0 +1,137 @@
+/**
+ * \file   Tag.h
+ * \author Lars Fröhlich
+ * \date   Created on July 17, 2024
+ * \brief  Declaration of the Tag class.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef TASKOLIB_TAG_H_
+#define TASKOLIB_TAG_H_
+
+#include <iosfwd>
+#include <string>
+
+#include <gul14/optional.h>
+#include <gul14/string_view.h>
+
+namespace task {
+
+/**
+ * A tag used for categorizing sequences.
+ *
+ * A tag consists of lowercase ASCII letters, digits, and hyphen characters. It must be at
+ * least 1 character long and has a maximum length given by the max_length member
+ * constant. Uppercase letters are automatically converted to lowercase when comparing or
+ * creating tags.
+ */
+class Tag
+{
+public:
+    /// Maximum number of bytes of a tag name.
+    static constexpr std::size_t max_length = 32;
+
+    /// A string containing all of the valid characters for a tag name.
+    static const gul14::string_view valid_characters;
+
+
+    /// Default-construct a tag with the name "-".
+    Tag() : name_{ "-" }
+    {}
+
+    /**
+     * Construct a tag with the specified name
+     *
+     * Uppercase ASCII characters are automatically converted to lowercase.
+     *
+     * \exception Error is thrown if the string is too long or if it contains invalid
+     *            characters.
+     */
+    explicit Tag(gul14::string_view name);
+
+    /**
+     * Create a Tag from the given string, returning an empty optional if the string
+     * violates length or character constraints.
+     *
+     * The uppercase ASCII characters A-Z are automatically converted to lowercase.
+     */
+    static gul14::optional<Tag> from_string(gul14::string_view name);
+
+    /// Determine if two tags are equal.
+    friend bool operator==(const Tag& a, const Tag& b)
+    {
+        return a.name_ == b.name_;
+    }
+
+    /// Determine if two tags are different.
+    friend bool operator!=(const Tag& a, const Tag& b)
+    {
+        return a.name_ != b.name_;
+    }
+
+    /// Determine if tag a comes before tag b in a lexicographical comparison.
+    friend bool operator<(const Tag& a, const Tag& b)
+    {
+        return a.name_ < b.name_;
+    }
+
+    /**
+     * Determine if tag a comes before or is equal to tag b in a lexicographical
+     * comparison.
+     */
+    friend bool operator<=(const Tag& a, const Tag& b)
+    {
+        return a.name_ <= b.name_;
+    }
+
+    /// Determine if tag a comes after tag b in a lexicographical comparison.
+    friend bool operator>(const Tag& a, const Tag& b)
+    {
+        return a.name_ > b.name_;
+    }
+
+    /**
+     * Determine if tag a comes after or is equal to tag b in a lexicographical
+     * comparison.
+     */
+    friend bool operator>=(const Tag& a, const Tag& b)
+    {
+        return a.name_ >= b.name_;
+    }
+
+    /// Output the tag name to the given stream.
+    friend std::ostream& operator<<(std::ostream& stream, const Tag& tag);
+
+    /// Return the name of the tag as a string.
+    const std::string& string() const noexcept { return name_; }
+
+private:
+    std::string name_;
+
+    /**
+     * Throw an exception if the given string violates the length or character constraints
+     * of a tag name; otherwise, return the unmodified string view. Uppercase ASCII
+     * characters are rejected.
+     */
+    static gul14::string_view check_validity(gul14::string_view);
+};
+
+} // namespace task
+
+#endif

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -748,6 +748,14 @@ void Sequence::set_step_setup_script(gul14::string_view step_setup_script)
     step_setup_script_.assign(step_setup_script.data(), step_setup_script.size());
 }
 
+void Sequence::set_tags(const std::vector<Tag>& new_tags)
+{
+    auto tags = new_tags;
+    std::sort(tags.begin(), tags.end());
+    tags.erase(std::unique(tags.begin(), tags.end()), tags.end());
+    tags_ = std::move(tags);
+}
+
 void Sequence::throw_if_full() const
 {
     if (steps_.size() == max_size())

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -76,6 +76,10 @@ void store_sequence_parameters(const std::filesystem::path& lua_file, const Sequ
 
     stream << "-- label: " << seq.get_label() << '\n';
     stream << "-- timeout: " << seq.get_timeout() << '\n';
+    stream << "-- tags:";
+    for (const Tag& tag : seq.get_tags())
+        stream << ' ' << tag;
+    stream << '\n';
     stream << seq;
 }
 

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -56,24 +56,7 @@ gul14::string_view Tag::check_validity(gul14::string_view name)
     return name;
 }
 
-gul14::optional<Tag> Tag::from_string(gul14::string_view name)
-{
-    try
-    {
-        return Tag{ name };
-    }
-    catch (const Error&)
-    {
-        return {};
-    }
-}
-
 const gul14::string_view Tag::valid_characters{ "abcdefghijklmnopqrstuvwxyz0123456789-" };
-
-
-//
-// Associated free functions
-//
 
 std::ostream& operator<<(std::ostream& stream, const Tag& tag)
 {

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -1,0 +1,83 @@
+/**
+ * \file   Tag.cc
+ * \author Lars Fröhlich
+ * \date   Created on July 17, 2024
+ * \brief  Implementation of the Tag class.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <ostream>
+
+#include <gul14/cat.h>
+#include <gul14/escape.h>
+#include <gul14/substring_checks.h>
+
+#include "taskolib/exceptions.h"
+#include "taskolib/Tag.h"
+
+using gul14::cat;
+
+namespace task {
+
+Tag::Tag(gul14::string_view name)
+    : name_{ check_validity(gul14::lowercase_ascii(name)) }
+{}
+
+gul14::string_view Tag::check_validity(gul14::string_view name)
+{
+    if (name.empty())
+        throw Error("Tag must not be empty");
+
+    if (name.size() > max_length)
+    {
+        throw Error(cat("Tag '", name, "' is too long: ", name.size(), " bytes > ",
+            max_length, " bytes"));
+    }
+
+    if (name.find_first_not_of(valid_characters) != gul14::string_view::npos)
+        throw Error(cat("Tag '", gul14::escape(name), "' contains invalid characters"));
+
+    return name;
+}
+
+gul14::optional<Tag> Tag::from_string(gul14::string_view name)
+{
+    try
+    {
+        return Tag{ name };
+    }
+    catch (const Error&)
+    {
+        return {};
+    }
+}
+
+const gul14::string_view Tag::valid_characters{ "abcdefghijklmnopqrstuvwxyz0123456789-" };
+
+
+//
+// Associated free functions
+//
+
+std::ostream& operator<<(std::ostream& stream, const Tag& tag)
+{
+    return stream << tag.name_;
+}
+
+} // namespace task

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -325,18 +325,9 @@ std::vector<Tag> parse_tags(gul14::string_view str)
 {
     const auto tokens = gul14::tokenize_sv(str);
 
-    std::vector<Tag> tags;
-    tags.reserve(tokens.size());
-
-    for (auto tok : tokens)
-    {
-        auto maybe_tag = Tag::from_string(tok);
-
-        // Silently drop invalid tags
-        if (maybe_tag)
-            tags.push_back(*maybe_tag);
-    }
-
+    std::vector<Tag> tags(tokens.size());
+    std::transform(tokens.begin(), tokens.end(), tags.begin(),
+                   [](gul14::string_view token) { return Tag{ token }; });
     return tags;
 }
 

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -1,8 +1,8 @@
 /**
- * \file   deserialize_sequence.cc
- * \author Marcus Walla
- * \date   Created on May 24, 2022
- * \brief  Deserialize Sequence and Steps from storage hardware.
+ * \file    deserialize_sequence.cc
+ * \authors Marcus Walla, Lars Fröhlich
+ * \date    Created on May 24, 2022
+ * \brief   Deserialize Sequence and Steps from storage hardware.
  *
  * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -311,12 +311,33 @@ void load_sequence_parameters(const std::filesystem::path& folder, Sequence& seq
                 sequence.set_label(gul14::trim_sv(keyword.substr(9)));
             else if (gul14::starts_with(keyword, "-- timeout:"))
                 sequence.set_timeout(parse_timeout(keyword.substr(11)));
+            else if (gul14::starts_with(keyword, "-- tags:"))
+                sequence.set_tags(parse_tags(keyword.substr(8)));
             else
                 step_setup_script += (line + '\n');
         }
     }
 
     sequence.set_step_setup_script(step_setup_script);
+}
+
+std::vector<Tag> parse_tags(gul14::string_view str)
+{
+    const auto tokens = gul14::tokenize_sv(str);
+
+    std::vector<Tag> tags;
+    tags.reserve(tokens.size());
+
+    for (auto tok : tokens)
+    {
+        auto maybe_tag = Tag::from_string(tok);
+
+        // Silently drop invalid tags
+        if (maybe_tag)
+            tags.push_back(*maybe_tag);
+    }
+
+    return tags;
 }
 
 } // namespace task

--- a/src/deserialize_sequence.h
+++ b/src/deserialize_sequence.h
@@ -1,8 +1,8 @@
 /**
- * \file   deserialize_sequence.h
- * \author Marcus Walla
- * \date   Created on May 24, 2022
- * \brief  Deserialize Sequence and Steps from storage hardware.
+ * \file    deserialize_sequence.h
+ * \authors Marcus Walla, Lars Fröhlich
+ * \date    Created on May 24, 2022
+ * \brief   Deserialize Sequence and Steps from storage hardware.
  *
  * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -27,9 +27,13 @@
 
 #include <filesystem>
 #include <iostream>
+#include <vector>
+
+#include <gul14/string_view.h>
 
 #include "taskolib/Sequence.h"
 #include "taskolib/Step.h"
+#include "taskolib/Tag.h"
 
 namespace task {
 
@@ -104,6 +108,13 @@ Step load_step(const std::filesystem::path& lua_file);
  * \see Sequence for step setup script.
  */
 void load_sequence_parameters(const std::filesystem::path& folder, Sequence& sequence);
+
+/**
+ * Parse a whitespace-separated string into a list of tags.
+ *
+ * Invalid tags are silently discarded.
+ */
+std::vector<Tag> parse_tags(gul14::string_view str);
 
 } // namespace task
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ sources = files(
     'SequenceName.cc',
     'serialize_sequence.cc',
     'Step.cc',
+    'Tag.cc',
     'time_types.cc',
     'UniqueId.cc',
     'VariableName.cc',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,6 +16,7 @@ test_src = files(
     'test_SequenceManager.cc',
     'test_serialize_sequence.cc',
     'test_Step.cc',
+    'test_Tag.cc',
     'test_time_types.cc',
     'test_Timeout.cc',
     'test_UniqueId.cc',

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -255,6 +255,12 @@ TEST_CASE("Sequence: get_name()", "[Sequence]")
     REQUIRE(s.get_name() == SequenceName{ "a_rose_by_any_other_name" });
 }
 
+TEST_CASE("Sequence: get_tags()", "[Sequence]")
+{
+    Sequence s;
+    REQUIRE(s.get_tags().empty());
+}
+
 TEST_CASE("Sequence: get_unique_id()", "[Sequence]")
 {
     Sequence seq1;

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -259,6 +259,14 @@ TEST_CASE("Sequence: get_tags()", "[Sequence]")
 {
     Sequence s;
     REQUIRE(s.get_tags().empty());
+
+    const std::vector<Tag> tags{ Tag{ "tag1" }, Tag{ "tag2" }, Tag{ "tag3" } };
+
+    s.set_tags(tags);
+    REQUIRE(s.get_tags() == tags);
+
+    s.set_tags(std::vector<Tag>{});
+    REQUIRE(s.get_tags().empty());
 }
 
 TEST_CASE("Sequence: get_unique_id()", "[Sequence]")
@@ -563,6 +571,23 @@ TEST_CASE("Sequence: set_running()", "[Sequence]")
         REQUIRE_THROWS_AS(seq.set_step_setup_script("b = 1"), Error);
         REQUIRE(seq.get_step_setup_script() == "");
     }
+}
+
+TEST_CASE("Sequence: set_tags()", "[Sequence]")
+{
+    Sequence s;
+
+    const std::vector<Tag> tags{ Tag{ "tag1" }, Tag{ "tag2" }, Tag{ "tag3" } };
+
+    s.set_tags(tags);
+    REQUIRE(s.get_tags() == tags);
+
+    s.set_tags(std::vector<Tag>{});
+    REQUIRE(s.get_tags().empty());
+
+    s.set_tags(
+        std::vector<Tag>{ Tag{ "TAG3" }, Tag{ "Tag2" }, Tag{ "tag3" }, Tag{ "tag1" } });
+    REQUIRE(s.get_tags() == tags);
 }
 
 TEST_CASE("Sequence: set_unique_id()", "[Sequence]")

--- a/tests/test_Tag.cc
+++ b/tests/test_Tag.cc
@@ -1,0 +1,134 @@
+/**
+ * \file   test_Tag.cc
+ * \author Lars Fröhlich
+ * \date   Created on July 17, 2024
+ * \brief  Test suite for the Tag class.
+ *
+ * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <sstream>
+
+#include <gul14/catch.h>
+
+#include "taskolib/exceptions.h"
+#include "taskolib/Tag.h"
+
+using namespace task;
+
+TEST_CASE("Tag: Default constructor", "[Tag]")
+{
+    Tag name;
+    REQUIRE(name.string() == "-");
+}
+
+TEST_CASE("Tag: Constructor from string", "[Tag]")
+{
+    Tag a{ "1234" };
+    Tag b{ "extremely-weird-Combination" };
+    Tag c{ "-1-a-B-C-" };
+
+    REQUIRE_THROWS_AS(Tag{ "" }, Error);
+    REQUIRE_THROWS_AS(Tag{ std::string(Tag::max_length + 1, 'a') }, Error);
+    REQUIRE_THROWS_AS(Tag{ "string with whitespace" }, Error);
+    REQUIRE_THROWS_AS(Tag{ "abcd#e" }, Error);
+    REQUIRE_THROWS_AS(Tag{ "abcd(e)" }, Error);
+    REQUIRE_THROWS_AS(Tag{ "abcd[e]" }, Error);
+    REQUIRE_THROWS_AS(Tag{ ".abcd" }, Error);
+}
+
+TEST_CASE("Tag: from_string()", "[Tag]")
+{
+    REQUIRE(Tag::from_string("1234") == Tag{ "1234" });
+    REQUIRE(Tag::from_string("extremely-weird-Combination")
+            == Tag{ "extremely-WEIRD-combination" });
+    REQUIRE(Tag::from_string("-1-a-B-C-") == Tag{ "-1-A-b-c-" });
+
+    REQUIRE(Tag::from_string("") == gul14::nullopt);
+    REQUIRE(Tag::from_string(std::string(Tag::max_length + 1, 'a')) == gul14::nullopt);
+    REQUIRE(Tag::from_string("string with whitespace") == gul14::nullopt);
+    REQUIRE(Tag::from_string("abcd#e") == gul14::nullopt);
+    REQUIRE(Tag::from_string("abcd(e)") == gul14::nullopt);
+    REQUIRE(Tag::from_string("abcd[e]") == gul14::nullopt);
+    REQUIRE(Tag::from_string(".abcd") == gul14::nullopt);
+}
+
+TEST_CASE("Tag: operator==()", "[Tag]")
+{
+    REQUIRE(Tag{ "1234" } == Tag{ "1234" });
+    REQUIRE(Tag{ "Gulag" } == Tag{ "gulag" });
+    REQUIRE_FALSE(Tag{ "hallo" } == Tag{ "hello" });
+}
+
+TEST_CASE("Tag: operator!=()", "[Tag]")
+{
+    REQUIRE_FALSE(Tag{ "1234" } != Tag{ "1234" });
+    REQUIRE_FALSE(Tag{ "Gulag" } != Tag{ "gulag" });
+    REQUIRE(Tag{ "hallo" } != Tag{ "hello" });
+}
+
+TEST_CASE("Tag: operator>()", "[Tag]")
+{
+    REQUIRE(Tag{ "12" } > Tag{ "11" });
+    REQUIRE(Tag{ "banana" } > Tag{ "apple" });
+    REQUIRE_FALSE(Tag{ "12" } > Tag{ "21" });
+    REQUIRE_FALSE(Tag{ "banana" } > Tag{ "cherry" });
+    REQUIRE_FALSE(Tag{ "apple" } > Tag{ "apple" });
+}
+
+TEST_CASE("Tag: operator>=()", "[Tag]")
+{
+    REQUIRE(Tag{ "12" } >= Tag{ "11" });
+    REQUIRE(Tag{ "banana" } >= Tag{ "apple" });
+    REQUIRE_FALSE(Tag{ "12" } >= Tag{ "21" });
+    REQUIRE_FALSE(Tag{ "banana" } >= Tag{ "cherry" });
+    REQUIRE(Tag{ "apple" } >= Tag{ "apple" });
+}
+
+TEST_CASE("Tag: operator<()", "[Tag]")
+{
+    REQUIRE_FALSE(Tag{ "12" } < Tag{ "11" });
+    REQUIRE_FALSE(Tag{ "banana" } < Tag{ "apple" });
+    REQUIRE(Tag{ "12" } < Tag{ "21" });
+    REQUIRE(Tag{ "banana" } < Tag{ "cherry" });
+    REQUIRE_FALSE(Tag{ "apple" } < Tag{ "apple" });
+}
+
+TEST_CASE("Tag: operator<=()", "[Tag]")
+{
+    REQUIRE_FALSE(Tag{ "12" } <= Tag{ "11" });
+    REQUIRE_FALSE(Tag{ "banana" } <= Tag{ "apple" });
+    REQUIRE(Tag{ "12" } <= Tag{ "21" });
+    REQUIRE(Tag{ "banana" } <= Tag{ "cherry" });
+    REQUIRE(Tag{ "apple" } <= Tag{ "apple" });
+}
+
+TEST_CASE("operator<<(std::ostream&, Tag)", "[Tag]")
+{
+    std::ostringstream stream;
+    stream << Tag{ "bloody" } << " " << Tag{ "sunday" };
+    REQUIRE(stream.str() == "bloody sunday");
+}
+
+TEST_CASE("Tag: string()", "[Tag]")
+{
+    REQUIRE(Tag{ "1234" }.string() == "1234");
+    REQUIRE(Tag{ "Extremely-Weird-Combination" }.string()
+            == "extremely-weird-combination");
+    REQUIRE(Tag{ "-1-a-B-C-" }.string() == "-1-a-b-c-");
+}

--- a/tests/test_Tag.cc
+++ b/tests/test_Tag.cc
@@ -52,22 +52,6 @@ TEST_CASE("Tag: Constructor from string", "[Tag]")
     REQUIRE_THROWS_AS(Tag{ ".abcd" }, Error);
 }
 
-TEST_CASE("Tag: from_string()", "[Tag]")
-{
-    REQUIRE(Tag::from_string("1234") == Tag{ "1234" });
-    REQUIRE(Tag::from_string("extremely-weird-Combination")
-            == Tag{ "extremely-WEIRD-combination" });
-    REQUIRE(Tag::from_string("-1-a-B-C-") == Tag{ "-1-A-b-c-" });
-
-    REQUIRE(Tag::from_string("") == gul14::nullopt);
-    REQUIRE(Tag::from_string(std::string(Tag::max_length + 1, 'a')) == gul14::nullopt);
-    REQUIRE(Tag::from_string("string with whitespace") == gul14::nullopt);
-    REQUIRE(Tag::from_string("abcd#e") == gul14::nullopt);
-    REQUIRE(Tag::from_string("abcd(e)") == gul14::nullopt);
-    REQUIRE(Tag::from_string("abcd[e]") == gul14::nullopt);
-    REQUIRE(Tag::from_string(".abcd") == gul14::nullopt);
-}
-
 TEST_CASE("Tag: operator==()", "[Tag]")
 {
     REQUIRE(Tag{ "1234" } == Tag{ "1234" });

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -27,4 +27,12 @@
 #include "deserialize_sequence.h"
 
 using namespace task;
-using namespace task::literals;
+
+TEST_CASE("parse_tags()", "[deserialize_sequence]")
+{
+    REQUIRE(parse_tags("").empty());
+    REQUIRE(parse_tags(" tag1 tag2\ttag3\n")
+        == std::vector{ Tag{ "tag1" }, Tag{ "tag2" }, Tag{ "tag3" } });
+    REQUIRE(parse_tags(" ta*g1 tag2\ttag3\nYet-Another-Tag")
+        == std::vector{ Tag{ "tag2" }, Tag{ "tag3" }, Tag{ "yet-another-tag" } });
+}

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -33,6 +33,8 @@ TEST_CASE("parse_tags()", "[deserialize_sequence]")
     REQUIRE(parse_tags("").empty());
     REQUIRE(parse_tags(" tag1 tag2\ttag3\n")
         == std::vector{ Tag{ "tag1" }, Tag{ "tag2" }, Tag{ "tag3" } });
-    REQUIRE(parse_tags(" ta*g1 tag2\ttag3\nYet-Another-Tag")
-        == std::vector{ Tag{ "tag2" }, Tag{ "tag3" }, Tag{ "yet-another-tag" } });
+    REQUIRE(parse_tags("c    Yet-Another-Tag")
+        == std::vector{ Tag{ "c" }, Tag{ "yet-another-tag" } });
+    REQUIRE_THROWS_AS(parse_tags("tag*"), Error);
+    REQUIRE_THROWS_AS(parse_tags("tag2 tag3 Yet-Another-Tag NOT_ALLOWED"), Error);
 }


### PR DESCRIPTION
This is the first step in the direction of a fully-fledged tagging system for Taskolib. We introduce a `Tag` class for tags like `production`, `test`, or `area-51`, and the `Sequence` class gets extended with `get_tags()` and `set_tags()` member functions. SerDes to the `sequence.lua` file is also included.

In the next step, we could extend the `SequenceManager` with functions to list the tags from all sequences.