### PR TITLE
Make parse_timeout() testable and more robust

### DIFF
--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -139,30 +139,6 @@ void extract_time_of_last_execution(gul14::string_view extract, Step& step)
     step.set_time_of_last_execution(extract_time("time of last execution", extract));
 }
 
-Timeout parse_timeout(gul14::string_view extract)
-{
-    auto start_timeout = extract.find_first_not_of(" \t");
-    if (start_timeout == std::string::npos)
-        throw Error(gul14::cat("timeout: unable to parse ('", extract, "')"));
-
-    auto timeout = gul14::trim(extract.substr(start_timeout));
-    if ("infinite" == timeout)
-    {
-        return Timeout::infinity();
-    }
-    else
-    {
-        try
-        {
-            return Timeout{std::chrono::milliseconds(std::stoull(timeout))};
-        }
-        catch(...) // catch any exception from std::stoull (Component::set_timeout throws)
-        {
-            throw Error(gul14::cat("timeout: unable to parse number ('", timeout, "')"));
-        }
-    }
-}
-
 void extract_disabled(gul14::string_view extract, Step& step)
 {
     bool val{ };
@@ -329,6 +305,30 @@ std::vector<Tag> parse_tags(gul14::string_view str)
     std::transform(tokens.begin(), tokens.end(), tags.begin(),
                    [](gul14::string_view token) { return Tag{ token }; });
     return tags;
+}
+
+Timeout parse_timeout(gul14::string_view str)
+{
+    auto start_timeout = str.find_first_not_of(" \t");
+    if (start_timeout == std::string::npos)
+        throw Error(gul14::cat("timeout: unable to parse ('", str, "')"));
+
+    auto timeout = gul14::trim(str.substr(start_timeout));
+    if ("infinite" == timeout)
+    {
+        return Timeout::infinity();
+    }
+    else
+    {
+        try
+        {
+            return Timeout{std::chrono::milliseconds(std::stoull(timeout))};
+        }
+        catch(...) // catch any exception from std::stoull (Component::set_timeout throws)
+        {
+            throw Error(gul14::cat("timeout: unable to parse number ('", timeout, "')"));
+        }
+    }
 }
 
 } // namespace task

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -309,26 +309,16 @@ std::vector<Tag> parse_tags(gul14::string_view str)
 
 Timeout parse_timeout(gul14::string_view str)
 {
-    auto start_timeout = str.find_first_not_of(" \t");
-    if (start_timeout == std::string::npos)
-        throw Error(gul14::cat("timeout: unable to parse ('", str, "')"));
+    str = gul14::trim_sv(str);
 
-    auto timeout = gul14::trim(str.substr(start_timeout));
-    if ("infinite" == timeout)
-    {
+    if (gul14::equals_nocase(str, "infinite"))
         return Timeout::infinity();
-    }
-    else
-    {
-        try
-        {
-            return Timeout{std::chrono::milliseconds(std::stoull(timeout))};
-        }
-        catch(...) // catch any exception from std::stoull (Component::set_timeout throws)
-        {
-            throw Error(gul14::cat("timeout: unable to parse number ('", timeout, "')"));
-        }
-    }
+
+    const auto maybe_msec = gul14::to_number<unsigned long long>(str);
+    if (!maybe_msec)
+        throw Error(gul14::cat("Cannot parse timeout from \"", str, '"'));
+
+    return Timeout{ std::chrono::milliseconds{ *maybe_msec } };
 }
 
 } // namespace task

--- a/src/deserialize_sequence.h
+++ b/src/deserialize_sequence.h
@@ -116,6 +116,16 @@ void load_sequence_parameters(const std::filesystem::path& folder, Sequence& seq
  */
 std::vector<Tag> parse_tags(gul14::string_view str);
 
+/**
+ * Parse a string into a Timeout value.
+ *
+ * The string may contain a (positive) number of milliseconds or the string "infinite". It
+ * may be surrounded by whitespace.
+ *
+ * \exception Error is thrown if the string does not represent a valid Timeout.
+ */
+Timeout parse_timeout(gul14::string_view str);
+
 } // namespace task
 
 #endif

--- a/src/deserialize_sequence.h
+++ b/src/deserialize_sequence.h
@@ -119,8 +119,8 @@ std::vector<Tag> parse_tags(gul14::string_view str);
 /**
  * Parse a string into a Timeout value.
  *
- * The string may contain a (positive) number of milliseconds or the string "infinite". It
- * may be surrounded by whitespace.
+ * The string may contain a positive, integral number of milliseconds or the string
+ * "infinite" in lower- or uppercase letters. It may be surrounded by whitespace.
  *
  * \exception Error is thrown if the string does not represent a valid Timeout.
  */

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -56,4 +56,6 @@ TEST_CASE("parse_timeout()", "[deserialize_sequence]")
     REQUIRE_THROWS_AS(parse_timeout("hello"), Error);
     REQUIRE_THROWS_AS(parse_timeout("10s"), Error);
     REQUIRE_THROWS_AS(parse_timeout("10 us"), Error);
+    REQUIRE_THROWS_AS(parse_timeout("-10"), Error);
+
 }

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -27,6 +27,7 @@
 #include "deserialize_sequence.h"
 
 using namespace task;
+using namespace std::literals;
 
 TEST_CASE("parse_tags()", "[deserialize_sequence]")
 {
@@ -37,4 +38,22 @@ TEST_CASE("parse_tags()", "[deserialize_sequence]")
         == std::vector{ Tag{ "c" }, Tag{ "yet-another-tag" } });
     REQUIRE_THROWS_AS(parse_tags("tag*"), Error);
     REQUIRE_THROWS_AS(parse_tags("tag2 tag3 Yet-Another-Tag NOT_ALLOWED"), Error);
+}
+
+TEST_CASE("parse_timeout()", "[deserialize_sequence]")
+{
+    REQUIRE(parse_timeout("0") == Timeout{ 0ms });
+    REQUIRE(parse_timeout("10") == Timeout{ 10ms });
+    REQUIRE(parse_timeout("30000") == Timeout{ 30s });
+    REQUIRE(parse_timeout(" 42 \t\n") == Timeout{ 42ms });
+    REQUIRE(parse_timeout("86400000") == Timeout{ 24h });
+    REQUIRE(parse_timeout("infinite") == Timeout::infinity());
+    REQUIRE(parse_timeout("Infinite") == Timeout::infinity());
+    REQUIRE(parse_timeout("INFINITE") == Timeout::infinity());
+    REQUIRE(parse_timeout("\ninfinite \t") == Timeout::infinity());
+
+    REQUIRE_THROWS_AS(parse_timeout(""), Error);
+    REQUIRE_THROWS_AS(parse_timeout("hello"), Error);
+    REQUIRE_THROWS_AS(parse_timeout("10s"), Error);
+    REQUIRE_THROWS_AS(parse_timeout("10 us"), Error);
 }


### PR DESCRIPTION
This PR extracts `parse_timeout()` from an anonymous namespace, adds documentation and unit tests, and fixes some unexpected behaviors like parsing "10 s" into a timeout of 10 milliseconds.