### PR TITLE
Tag: Add operator+ to concatenate strings and Tags

### DIFF
--- a/include/taskolib/Tag.h
+++ b/include/taskolib/Tag.h
@@ -106,6 +106,18 @@ public:
         return a.name_ >= b.name_;
     }
 
+    /// Concatenate a string and a tag.
+    friend std::string operator+(const std::string& lhs, const Tag& rhs)
+    {
+        return lhs + rhs.name_;
+    }
+
+    /// Concatenate a tag and a string.
+    friend std::string operator+(const Tag& lhs, const std::string& rhs)
+    {
+        return lhs.name_ + rhs;
+    }
+
     /// Output the tag name to the given stream.
     friend std::ostream& operator<<(std::ostream& stream, const Tag& tag);
 

--- a/include/taskolib/Tag.h
+++ b/include/taskolib/Tag.h
@@ -118,6 +118,13 @@ public:
         return lhs.name_ + rhs;
     }
 
+    /// Concatenate a string and a tag.
+    friend std::string& operator+=(std::string& lhs, const Tag& rhs)
+    {
+        lhs += rhs.name_;
+        return lhs;
+    }
+
     /// Output the tag name to the given stream.
     friend std::ostream& operator<<(std::ostream& stream, const Tag& tag);
 

--- a/tests/test_Tag.cc
+++ b/tests/test_Tag.cc
@@ -113,6 +113,13 @@ TEST_CASE("operator+(Tag, string)", "[Tag]")
     REQUIRE(Tag{ "gung" } + "-ho"s == "gung-ho");
 }
 
+TEST_CASE("operator+=(string, Tag)", "[Tag]")
+{
+    std::string str = "Hello ";
+    str += Tag{ "world" };
+    REQUIRE(str == "Hello world");
+}
+
 TEST_CASE("operator<<(std::ostream&, Tag)", "[Tag]")
 {
     std::ostringstream stream;

--- a/tests/test_Tag.cc
+++ b/tests/test_Tag.cc
@@ -29,6 +29,7 @@
 #include "taskolib/exceptions.h"
 #include "taskolib/Tag.h"
 
+using namespace std::literals;
 using namespace task;
 
 TEST_CASE("Tag: Default constructor", "[Tag]")
@@ -100,6 +101,16 @@ TEST_CASE("Tag: operator<=()", "[Tag]")
     REQUIRE(Tag{ "12" } <= Tag{ "21" });
     REQUIRE(Tag{ "banana" } <= Tag{ "cherry" });
     REQUIRE(Tag{ "apple" } <= Tag{ "apple" });
+}
+
+TEST_CASE("operator+(string, Tag)", "[Tag]")
+{
+    REQUIRE("Hello "s + Tag{ "world" } == "Hello world");
+}
+
+TEST_CASE("operator+(Tag, string)", "[Tag]")
+{
+    REQUIRE(Tag{ "gung" } + "-ho"s == "gung-ho");
 }
 
 TEST_CASE("operator<<(std::ostream&, Tag)", "[Tag]")


### PR DESCRIPTION
This PR adds an `operator+(const std::string&, const Tag&)` and an `operator(const Tag&, const std::string&)`. This is a prerequisite for using `gul14::join()` with a container full of `Tag`s, but it is also useful in general.