### PR TITLE
Add automation flag to the sequence.

### DIFF
--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -401,6 +401,9 @@ public:
     /// Return the tags associated with this sequence in alphabetical order.
     const std::vector<Tag>& get_tags() const noexcept { return tags_; }
 
+    /// Return true if automated execution is active otherwise false.
+    bool get_automation() const noexcept { return automation_; }
+
     /**
      * Determine when the sequence was last executed.
      *
@@ -667,6 +670,14 @@ public:
      */
     void set_tags(const std::vector<Tag>& tags);
 
+    /**
+     * Set the automation flag.
+     *
+     * If the flag is set the sequence can be automatically triggered by an external
+     * call.
+     */
+    void set_automation(bool automation);
+
     /// Set the timeout duration for executing the sequence.
     void set_timeout(Timeout timeout) { timeout_trigger_.set_timeout(timeout); }
 
@@ -697,6 +708,7 @@ private:
     std::string maintainers_;       ///< One or more maintainers.
     std::string step_setup_script_; ///< Step setup script.
     std::vector<Tag> tags_;         ///< Tags for categorizing the sequence.
+    bool automation_{ false };      ///< Flag for automatic execution.
     std::vector<Step> steps_;       ///< Collection of steps.
 
     bool is_running_{ false }; ///< Flag to determine if the sequence is running.

--- a/src/Sequence.cc
+++ b/src/Sequence.cc
@@ -67,6 +67,7 @@ find_end_of_indented_block(IteratorT begin, IteratorT end, short min_indentation
 Sequence::Sequence(gul14::string_view label, SequenceName name, UniqueId uid)
     : unique_id_{ uid }
     , name_{ std::move(name) }
+    , automation_{ false }
 {
     set_label(label);
 }
@@ -754,6 +755,11 @@ void Sequence::set_tags(const std::vector<Tag>& new_tags)
     std::sort(tags.begin(), tags.end());
     tags.erase(std::unique(tags.begin(), tags.end()), tags.end());
     tags_ = std::move(tags);
+}
+
+void Sequence::set_automation(bool automation)
+{
+    automation_ = automation;
 }
 
 void Sequence::throw_if_full() const

--- a/src/deserialize_sequence.h
+++ b/src/deserialize_sequence.h
@@ -38,6 +38,17 @@
 namespace task {
 
 /**
+ * Deserialize parameters of Sequence from the input stream.
+ *
+ * No checking of any stream failure is done and should be performed by the caller.
+ *
+ * \param stream input stream
+ * \param sequence Sequence to be deserialized.
+ * \return passed input stream
+ */
+std::istream& operator>>(std::istream& stream, Sequence& sequence);
+
+/**
  * Deserialize parameters of Step from the input stream.
  *
  * No checking of any stream failure is done and should be performed by the caller.
@@ -121,6 +132,11 @@ void load_sequence_parameters(const std::filesystem::path& folder, Sequence& seq
  * \exception Error is thrown if a tag with an invalid name is encountered.
  */
 std::vector<Tag> parse_tags(gul14::string_view str);
+
+/**
+ * Parse the automation flag from a string.
+ */
+bool parse_automation(gul14::string_view str);
 
 /**
  * Parse a string into a Timeout value.

--- a/src/serialize_sequence.cc
+++ b/src/serialize_sequence.cc
@@ -103,6 +103,7 @@ void store_step(const std::filesystem::path& lua_file, const Step& step)
 
 std::ostream& operator<<(std::ostream& stream, const Sequence& sequence)
 {
+    stream << "-- automation: " << (sequence.get_automation() ? "true" : "false") << '\n';
     stream << sequence.get_step_setup_script();
 
     check_stream(stream);

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -4069,3 +4069,14 @@ TEST_CASE("Sequence: label with control character", "[serialize_sequence]")
     Sequence sequence{ "Test sequence" };
     REQUIRE_THROWS_AS(sequence.set_label("A\bbell"), Error);
 }
+
+TEST_CASE("Sequence: sequence automation", "[Sequence]")
+{
+    Sequence seq("test_sequence");
+
+    REQUIRE_FALSE(seq.get_automation());
+    seq.set_automation(true);
+    REQUIRE(seq.get_automation());
+    seq.set_automation(false);
+    REQUIRE_FALSE(seq.get_automation());
+}

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -59,3 +59,13 @@ TEST_CASE("parse_timeout()", "[deserialize_sequence]")
     REQUIRE_THROWS_AS(parse_timeout("-10"), Error);
 
 }
+
+TEST_CASE("parse_automation()", "[deserialize_sequence]")
+{
+    REQUIRE(parse_automation("true"));
+    REQUIRE_FALSE(parse_automation("false"));
+
+    REQUIRE_FALSE(parse_automation("TRUE"));
+    REQUIRE_FALSE(parse_automation(""));
+    REQUIRE_FALSE(parse_automation("1"));
+}

--- a/tests/test_serialize_sequence.cc
+++ b/tests/test_serialize_sequence.cc
@@ -30,6 +30,7 @@
 
 #include "deserialize_sequence.h"
 #include "serialize_sequence.h"
+#include "taskolib/Sequence.h"
 
 using namespace std::literals;
 using namespace task;
@@ -48,6 +49,47 @@ TEST_CASE("make_sequence_filename(SequenceName, UniqueId)", "[serialize_sequence
     REQUIRE(make_sequence_filename(SequenceName{ "my_seq_name" }, 1_uid)
         == "my_seq_name[0000000000000001]");
     REQUIRE(make_sequence_filename(SequenceName{}, 0x1234_uid) == "[0000000000001234]");
+}
+
+TEST_CASE("automation sequence", "[serialize_sequence]")
+{
+    std::stringstream ss;
+
+    Sequence seq("test_sequence");
+
+    SECTION("serialize: automation")
+    {
+        seq.set_automation(true);
+
+        ss << seq;
+
+        Sequence deserialize;
+        ss >> deserialize;
+
+        REQUIRE(deserialize.get_automation());
+    }
+
+    SECTION("serialize: default automation")
+    {
+        ss << seq;
+
+        Sequence deserialize;
+        ss >> deserialize;
+
+        REQUIRE_FALSE(deserialize.get_automation());
+    }
+
+    SECTION("serialize: no automation")
+    {
+        seq.set_automation(false);
+
+        ss << seq;
+
+        Sequence deserialize;
+        ss >> deserialize;
+
+        REQUIRE_FALSE(deserialize.get_automation());
+    }
 }
 
 TEST_CASE("serialize_sequence: simple step", "[serialize_sequence]")


### PR DESCRIPTION
[why]
Add new automation flag to a sequence. This flag is only informative and has no meaning to it but can be used by a third party to allow an automatic execution of the sequence when it is started.

[how]
- Add to the `Sequence` the automation flag with getter and setter member function.
- Allow to marshal the automation flag.

See issue #122. 