### PR TITLE
Migrate to Catch2v3 and GUL17

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -45,7 +45,7 @@ jobs:
       uses: robinraju/release-downloader@v1.8
       with:
         repository: "mesonbuild/meson"
-        tag: "0.53.2"
+        tag: "1.3.2"
         fileName: "*.tar.gz"
     - name: Unpack meson tar ball and remove downloaded file
       run: |

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -62,8 +62,8 @@ jobs:
 
     - name: Configure build directories
       run: |
-        ./meson.py --wrap-mode forcefallback --buildtype=release build.release
-        ./meson.py --wrap-mode forcefallback --buildtype=debug build.asan -Db_sanitize=address
+        ./meson.py --wrap-mode forcefallback -Dgul17:tests=false --buildtype=release build.release
+        ./meson.py --wrap-mode forcefallback -Dgul17:tests=false --buildtype=debug build.asan -Db_sanitize=address
     - name: Build and run release tests
       id: buildnormal
       run: |

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build and Tests
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     steps:
     - run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 docs/html/
 build*/
 subprojects/*/
+unit_test_files/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Lars Froehlich <lars.froehlich@desy.de>
 Standards-Version: 4.6.0
-Build-Depends: libgit4cpp-dev, gul17-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12)
+Build-Depends: libgit4cpp-dev, gul17-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12), libcatch2-dev
 
 Package: taskolib-1-4-4
 Section: libs

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Lars Froehlich <lars.froehlich@desy.de>
 Standards-Version: 4.6.0
-Build-Depends: libgit4cpp-dev, dev-doocs-libgul14 | libgul14-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12)
+Build-Depends: libgit4cpp-dev, gul17-dev, meson (>=0.49.0), pkg-config, debhelper-compat (=12)
 
 Package: taskolib-1-4-4
 Section: libs

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Description: Taskolib automatization library - runtime
 Package: taskolib-dev
 Section: libdevel
 Architecture: any
-Depends: ${S:Source}
+Depends: libgit4cpp-dev, gul17-dev, ${S:Source}
 Replaces: libtaskomat-dev
 Breaks: libtaskomat-dev
 Description: Taskolib automatization library - dev files

--- a/include/taskolib/LockedQueue.h
+++ b/include/taskolib/LockedQueue.h
@@ -4,7 +4,7 @@
  * \date   Created on April 1, 2022
  * \brief  Declaration of the LockedQueue class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,8 +27,9 @@
 
 #include <condition_variable>
 #include <mutex>
-#include <gul14/optional.h>
-#include <gul14/SlidingBuffer.h>
+#include <optional>
+
+#include <gul17/SlidingBuffer.h>
 
 namespace task {
 
@@ -161,12 +162,12 @@ public:
      *
      * \see try_pop()
      */
-    gul14::optional<MessageType> try_pop()
+    std::optional<MessageType> try_pop()
     {
         std::unique_lock<std::mutex> lock(mutex_);
 
         if (queue_.empty())
-            return gul14::nullopt;
+            return std::nullopt;
 
         auto msg = std::move(queue_.front());
         queue_.pop_front();
@@ -209,7 +210,7 @@ private:
     /// Condition variable, triggered when at least one slot in the queue has been freed.
     mutable std::condition_variable cv_slot_available_;
 
-    gul14::SlidingBuffer<MessageType> queue_;
+    gul17::SlidingBuffer<MessageType> queue_;
 };
 
 } // namespace task

--- a/include/taskolib/Message.h
+++ b/include/taskolib/Message.h
@@ -1,10 +1,10 @@
 /**
- * \file   Message.h
- * \author Lars Fröhlich, Marcus Walla
- * \date   Created on April 1, 2022
- * \brief  Declaration of the Message class.
+ * \file    Message.h
+ * \authors Lars Fröhlich, Marcus Walla
+ * \date    Created on April 1, 2022
+ * \brief   Declaration of the Message class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -30,7 +30,7 @@
 #include <ostream>
 #include <string>
 
-#include <gul14/escape.h>
+#include <gul17/escape.h>
 
 #include "taskolib/StepIndex.h"
 #include "taskolib/time_types.h"
@@ -128,7 +128,7 @@ public:
         stream
             << mess.type_
             << " \""
-            << gul14::escape(mess.text_)
+            << gul17::escape(mess.text_)
             << "\" "
             << to_string(mess.timestamp_)
             << " }\n";

--- a/include/taskolib/Sequence.h
+++ b/include/taskolib/Sequence.h
@@ -4,7 +4,7 @@
  * \date    Created on February 8, 2022
  * \brief   A sequence of Steps.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,19 +26,18 @@
 #define TASKOLIB_SEQUENCE_H_
 
 #include <algorithm>
-#include <chrono>
 #include <filesystem>
 #include <functional>
 #include <limits>
+#include <optional>
+#include <string_view>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <gul14/cat.h>
-#include <gul14/finalizer.h>
-#include <gul14/optional.h>
-#include <gul14/string_view.h>
-#include <gul14/traits.h>
+#include <gul17/cat.h>
+#include <gul17/finalizer.h>
+#include <gul17/traits.h>
 
 #include "taskolib/CommChannel.h"
 #include "taskolib/Context.h"
@@ -184,7 +183,7 @@ public:
      * \exception Error is thrown if the label is too long or if it contains at least one
      *            control character.
      */
-    Sequence(gul14::string_view label = "", SequenceName name = SequenceName{},
+    Sequence(std::string_view label = "", SequenceName name = SequenceName{},
         UniqueId uid = UniqueId{});
 
     /**
@@ -361,15 +360,15 @@ public:
      *          and can be retrieved with get_error().
      */
     [[nodiscard]]
-    gul14::optional<Error> execute(Context& context, CommChannel* comm_channel,
-                                   OptionalStepIndex opt_step_index = gul14::nullopt);
+    std::optional<Error> execute(Context& context, CommChannel* comm_channel,
+                                   OptionalStepIndex opt_step_index = std::nullopt);
 
     /**
      * Return an optional Error object explaining why the sequence stopped prematurely.
      *
      * If the sequence finished normally, nullopt is returned.
      */
-    gul14::optional<Error> get_error() const { return error_; }
+    std::optional<Error> get_error() const { return error_; }
 
     /**
      * Return the (relative) folder name associated with this sequence.
@@ -437,7 +436,7 @@ public:
      *            or if it is currently running.
      */
     template <typename StepType, std::enable_if_t<
-        std::is_same<gul14::remove_cvref_t<StepType>, Step>::value, bool> = true>
+        std::is_same<gul17::remove_cvref_t<StepType>, Step>::value, bool> = true>
     ConstIterator insert(ConstIterator iter, StepType step)
     {
         throw_if_running();
@@ -509,7 +508,7 @@ public:
         const auto it = steps_.begin() + (iter - steps_.cbegin());
 
         // Reindent at the end of the function, even if an exception is thrown
-        auto indent_if_necessary = gul14::finally(
+        auto indent_if_necessary = gul17::finally(
             [this,
              it,
              old_indentation_level = it->get_indentation_level(),
@@ -610,7 +609,7 @@ public:
      *
      * \see get_error()
      */
-    void set_error(gul14::optional<Error> opt_error);
+    void set_error(std::optional<Error> opt_error);
 
     /**
      * Set the human-readable sequence label.
@@ -624,7 +623,7 @@ public:
      * \exception Error is thrown if the label is empty, its length exceeds
      *            max_label_length bytes or has some control characters.
      */
-    void set_label(gul14::string_view label);
+    void set_label(std::string_view label);
 
     /**
      * Add one or more maintainers to the sequence. You are free to choose what ever you
@@ -637,7 +636,7 @@ public:
      *
      * \exception Error is thrown if control characters are detected.
      */
-    void set_maintainers(gul14::string_view maintainers);
+    void set_maintainers(std::string_view maintainers);
 
     /**
      * Set the machine-friendly sequence name.
@@ -664,7 +663,7 @@ public:
      *
      * \exception Error is thrown if the sequence is currently running.
      */
-    void set_step_setup_script(gul14::string_view step_setup_script);
+    void set_step_setup_script(std::string_view step_setup_script);
 
     /**
      * Set the tags associated with this sequence.
@@ -703,7 +702,7 @@ private:
      * An optional Error object describing why the Sequence stopped prematurely (if it has
      * a value) or that it finished normally (if it is nullopt).
      */
-    gul14::optional<Error> error_;
+    std::optional<Error> error_;
 
     /// Empty if indentation is correct and complete, error message otherwise
     std::string indentation_error_;
@@ -915,9 +914,9 @@ private:
      *          object if anything went wrong.
      */
     [[nodiscard]]
-    gul14::optional<Error>
+    std::optional<Error>
     handle_execution(Context& context, CommChannel* comm_channel,
-                     gul14::string_view exec_block_name,
+                     std::string_view exec_block_name,
                      std::function<void(Context&, CommChannel*)> runner);
 
     /**
@@ -944,7 +943,7 @@ private:
      * Throw a syntax error for the specified step.
      * The error message reports the step number.
      */
-    void throw_syntax_error_for_step(ConstIterator it, gul14::string_view msg) const;
+    void throw_syntax_error_for_step(ConstIterator it, std::string_view msg) const;
 };
 
 } // namespace task

--- a/include/taskolib/SequenceManager.h
+++ b/include/taskolib/SequenceManager.h
@@ -4,7 +4,7 @@
  * \date    Created on July 22, 2022
  * \brief   Manage and control sequences.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,11 +26,11 @@
 #define TASKOLIB_SEQUENCEMANAGER_H_
 
 #include <filesystem>
+#include <optional>
+#include <string_view>
 #include <string>
 #include <vector>
 
-#include <gul14/optional.h>
-#include <gul14/string_view.h>
 #include <libgit4cpp/Repository.h>
 
 #include "taskolib/Sequence.h"
@@ -119,7 +119,7 @@ public:
      *
      * \exception Error is thrown if the sequence folder cannot be created.
      */
-    Sequence create_sequence(gul14::string_view label = "", SequenceName name = SequenceName{});
+    Sequence create_sequence(std::string_view label = "", SequenceName name = SequenceName{});
 
     /**
      * Return the base path of the serialized sequences.
@@ -198,7 +198,7 @@ public:
      * and unique ID. If the folder does not follow the naming scheme, nullopt is
      * returned.
      */
-    static gul14::optional<SequenceOnDisk>
+    static std::optional<SequenceOnDisk>
     parse_folder_name(const std::filesystem::path& folder);
 
     /**
@@ -331,7 +331,7 @@ private:
                 commit_body = stage_files_in_directory(extra_dir);
             if (commit_body.empty())
                 return false;
-            git_repo_.commit(gul14::cat(message, "\n", commit_body));
+            git_repo_.commit(gul17::cat(message, "\n", commit_body));
         }
         catch (std::exception const& e) {
             try {
@@ -380,7 +380,7 @@ private:
         const std::vector<SequenceOnDisk>& sequences);
 
     /// Generate a machine-friendly sequence name from a human-readable label.
-    static SequenceName make_sequence_name_from_label(gul14::string_view label);
+    static SequenceName make_sequence_name_from_label(std::string_view label);
 
     /**
      * Actually write a sequence to disk (without commit in git)

--- a/include/taskolib/SequenceName.h
+++ b/include/taskolib/SequenceName.h
@@ -4,7 +4,7 @@
  * \date   Created on August 25, 2023, based on older code
  * \brief  Declaration of the SequenceName class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,10 +25,9 @@
 #ifndef TASKOLIB_SEQUENCENAME_H_
 #define TASKOLIB_SEQUENCENAME_H_
 
+#include <optional>
+#include <string_view>
 #include <string>
-
-#include <gul14/optional.h>
-#include <gul14/string_view.h>
 
 namespace task {
 
@@ -47,7 +46,7 @@ public:
     static constexpr std::size_t max_length = 64;
 
     /// A string containing all of the valid characters of a sequence name.
-    static const gul14::string_view valid_characters;
+    static const std::string_view valid_characters;
 
 
     /// Default-construct an empty sequence name.
@@ -58,13 +57,13 @@ public:
      * \exception Error is thrown if the string is too long or if it contains invalid
      *            characters.
      */
-    explicit SequenceName(gul14::string_view str);
+    explicit SequenceName(std::string_view str);
 
     /**
      * Create a sequence name from the given string, returning an empty optional if the
      * string violates the length or character constraints of a sequence name.
      */
-    static gul14::optional<SequenceName> from_string(gul14::string_view str);
+    static std::optional<SequenceName> from_string(std::string_view str);
 
     /// Determine if two sequence names are equal.
     friend bool operator==(const SequenceName& a, const SequenceName& b)
@@ -88,7 +87,7 @@ private:
      * Throw an exception if the given string violates the length or character constraints
      * of a sequence name; otherwise, return the unmodified string view.
      */
-    static gul14::string_view check_validity(gul14::string_view);
+    static std::string_view check_validity(std::string_view);
 };
 
 } // namespace task

--- a/include/taskolib/Step.h
+++ b/include/taskolib/Step.h
@@ -116,7 +116,7 @@ public:
      * \see For more information about step setup scripts see at Sequence.
      */
     bool execute(Context& context, CommChannel* comm_channel = nullptr,
-                 OptionalStepIndex opt_step_index = gul14::nullopt,
+                 OptionalStepIndex opt_step_index = std::nullopt,
                  TimeoutTrigger* sequence_timeout = nullptr);
 
     /**

--- a/include/taskolib/StepIndex.h
+++ b/include/taskolib/StepIndex.h
@@ -4,7 +4,7 @@
  * \date   Created on October 18, 2022
  * \brief  Declaration of the StepIndex type.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,15 +26,15 @@
 #define TASKOLIB_STEPINDEX_H_
 
 #include <cstdint>
-#include <gul14/optional.h>
+#include <optional>
 
 namespace task {
 
 /// A type for storing the index of a Step in a Sequence.
 using StepIndex = std::uint16_t;
 
-/// An optional step index (gul14::optional<StepIndex>).
-using OptionalStepIndex = gul14::optional<StepIndex>;
+/// An optional step index (std::optional<StepIndex>).
+using OptionalStepIndex = std::optional<StepIndex>;
 
 } // namespace task
 

--- a/include/taskolib/Tag.h
+++ b/include/taskolib/Tag.h
@@ -4,7 +4,7 @@
  * \date   Created on July 17, 2024
  * \brief  Declaration of the Tag class.
  *
- * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2024-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,9 +26,8 @@
 #define TASKOLIB_TAG_H_
 
 #include <iosfwd>
+#include <string_view>
 #include <string>
-
-#include <gul14/string_view.h>
 
 namespace task {
 
@@ -47,7 +46,7 @@ public:
     static constexpr std::size_t max_length = 32;
 
     /// A string containing all of the valid characters for a tag name.
-    static const gul14::string_view valid_characters;
+    static const std::string_view valid_characters;
 
 
     /// Default-construct a tag with the name "-".
@@ -62,7 +61,7 @@ public:
      * \exception Error is thrown if the string is too long or if it contains invalid
      *            characters.
      */
-    explicit Tag(gul14::string_view name);
+    explicit Tag(std::string_view name);
 
     /// Determine if two tags are equal.
     friend bool operator==(const Tag& a, const Tag& b)
@@ -142,7 +141,7 @@ private:
      * of a tag name; otherwise, return the unmodified string view. Uppercase ASCII
      * characters are rejected.
      */
-    static gul14::string_view check_validity(gul14::string_view);
+    static std::string_view check_validity(std::string_view);
 };
 
 } // namespace task

--- a/include/taskolib/UniqueId.h
+++ b/include/taskolib/UniqueId.h
@@ -4,7 +4,7 @@
  * \date   Created on July 26, 2023
  * \brief  Declaration of the UniqueId class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,11 +25,10 @@
 #ifndef TASKOLIB_UNIQUEID_H_
 #define TASKOLIB_UNIQUEID_H_
 
+#include <optional>
 #include <random>
+#include <string_view>
 #include <string>
-
-#include <gul14/optional.h>
-#include <gul14/string_view.h>
 
 namespace task {
 
@@ -54,7 +53,7 @@ public:
      * The string must represent a hexadecimal number with a maximum of 16 characters.
      * Neither leading whitespace nor a "0x" prefix are allowed.
      */
-    static gul14::optional<UniqueId> from_string(gul14::string_view str);
+    static std::optional<UniqueId> from_string(std::string_view str);
 
     /// Determine if two unique IDs are equal.
     friend bool operator==(UniqueId a, UniqueId b)

--- a/include/taskolib/VariableName.h
+++ b/include/taskolib/VariableName.h
@@ -5,7 +5,7 @@
  * \brief  Declaration of the VariableName class and of an associated specialization of
  *         std::hash.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -28,7 +28,9 @@
 
 #include <functional>
 #include <string>
-#include <gul14/string_view.h>
+#include <string_view>
+
+#include <gul17/cat.h>
 
 namespace task {
 
@@ -114,7 +116,7 @@ public:
      *
      * \exception Error is thrown if the resulting variable name is not valid.
      */
-    VariableName& operator+=(gul14::string_view suffix);
+    VariableName& operator+=(std::string_view suffix);
 
     /// Append a VariableName to a std::string.
     friend std::string& operator+=(std::string& lhs, const VariableName& rhs)
@@ -124,15 +126,15 @@ public:
     }
 
     /// Concatenate a VariableName and a string_view.
-    friend std::string operator+(const VariableName& lhs, gul14::string_view rhs)
+    friend std::string operator+(const VariableName& lhs, std::string_view rhs)
     {
-        return lhs.string() + rhs;
+        return gul17::cat(lhs.string(), rhs);
     }
 
     /// Concatenate a string_view and a VariableName.
-    friend std::string operator+(gul14::string_view lhs, const VariableName& rhs)
+    friend std::string operator+(std::string_view lhs, const VariableName& rhs)
     {
-        return lhs + rhs.string();
+        return gul17::cat(lhs, rhs.string());
     }
 
     /// Convert the VariableName to a std::string.

--- a/include/taskolib/exceptions.h
+++ b/include/taskolib/exceptions.h
@@ -72,12 +72,12 @@ namespace task {
 class Error : public std::runtime_error
 {
 public:
-    explicit Error(const std::string& msg, OptionalStepIndex opt_step_index = gul14::nullopt)
+    explicit Error(const std::string& msg, OptionalStepIndex opt_step_index = std::nullopt)
         : std::runtime_error(msg)
         , index_{ opt_step_index }
     {}
 
-    explicit Error(const char* msg, OptionalStepIndex opt_step_index = gul14::nullopt)
+    explicit Error(const char* msg, OptionalStepIndex opt_step_index = std::nullopt)
         : std::runtime_error(msg)
         , index_{ opt_step_index }
     {}

--- a/include/taskolib/execute_lua_script.h
+++ b/include/taskolib/execute_lua_script.h
@@ -4,7 +4,7 @@
  * \date   Created on November 15, 2022
  * \brief  Declaration of execute_lua_script() and load_lua_script().
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,7 +27,7 @@
 
 #include <string>
 
-#include <gul14/expected.h>
+#include <gul17/expected.h>
 
 #include "sol/sol.hpp"
 
@@ -37,20 +37,20 @@ namespace task {
  * Execute a Lua script safely, intercepting all possible exceptions that may occur during
  * its execution.
  *
- * This function returns a gul14::expected object: If the Lua script finishes without
+ * This function returns a gul17::expected object: If the Lua script finishes without
  * error, it contains a sol::object representing the return value of the script. If a Lua
  * error or C++ exception occurs, the returned object contains a string with an error message. The
  * error message is pre-processed to a certain degree: Unhelpful parts like the chunk name
  * of the script (`[string "..."]:`) are removed, and a few known special messages are
  * replaced by more readable explanations.
  */
-gul14::expected<sol::object, std::string>
+gul17::expected<sol::object, std::string>
 execute_lua_script(sol::state& lua, sol::string_view script);
 
 /**
  * Load a Lua script into the given Lua state and check its syntax without running it.
  *
- * This function returns a gul14::expected object: If the syntax of the Lua script is OK,
+ * This function returns a gul17::expected object: If the syntax of the Lua script is OK,
  * it contains a sol::load_result proxy object that can be called to run the script or
  * cast to a sol::function/sol::protected_function. If the syntax check fails, a string
  * with an error message is returned instead. This error message is pre-processed to a
@@ -58,7 +58,7 @@ execute_lua_script(sol::state& lua, sol::string_view script);
  * are removed, and a few known special messages are replaced by more readable
  * explanations.
  */
-gul14::expected<sol::load_result, std::string>
+gul17::expected<sol::load_result, std::string>
 load_lua_script(sol::state& lua, sol::string_view script);
 
 

--- a/include/taskolib/hash_string.h
+++ b/include/taskolib/hash_string.h
@@ -35,14 +35,14 @@
 #ifndef TASKOLIB_CASE_STRING_H_
 #define TASKOLIB_CASE_STRING_H_
 
-#include <gul14/string_view.h>
+#include <string_view>
 
 namespace task {
 
 /// Adapt switch statement with stringify items:
 /// https://learnmoderncpp.com/2020/06/01/strings-as-switch-case-labels/
 /// Version 1.4: 2022/01/15, MIT license, (c) 2020-22 Richard Spencer
-inline constexpr unsigned long hash_djb2a(gul14::string_view sv) {
+inline constexpr unsigned long hash_djb2a(std::string_view sv) {
     unsigned long hash{ 5381 };
     for (unsigned char c : sv) {
         hash = ((hash << 5) + hash) ^ c;
@@ -54,7 +54,7 @@ inline constexpr unsigned long hash_djb2a(gul14::string_view sv) {
 /// https://learnmoderncpp.com/2020/06/01/strings-as-switch-case-labels/
 /// Version 1.4: 2022/01/15, MIT license, (c) 2020-22 Richard Spencer
 inline constexpr unsigned long operator"" _sh(const char *str, std::size_t len) {
-    return hash_djb2a(gul14::string_view{ str, len });
+    return hash_djb2a(std::string_view{ str, len });
 }
 
 } // namespace task

--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ subdir('src/lua')
 
 inc = [ include_directories('include', 'include/taskolib/sol', 'src') ]
 
-gul_dep = dependency('libgul14', version : '> 2.6', fallback : ['libgul14', 'libgul_dep'])
+gul_dep = dependency('gul17', version : '> 2.6', fallback : ['gul17', 'libgul_dep'])
 
 deps = [
     dependency('threads'),
@@ -99,7 +99,7 @@ pkg.generate(lib,
     version : libno,
     filebase : pkg_config_name,
     libraries : [ '-Wl,-rpath,${libdir}' ],
-    requires : [ 'libgul14', 'libgit4cpp' ],
+    requires : [ 'gul17', 'libgit4cpp' ],
     subdirs : [ '', 'taskolib' / 'sol' + sol_version, 'taskolib' / 'lua' + lua_version, ],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ subdir('src/lua')
 
 inc = [ include_directories('include', 'include/taskolib/sol', 'src') ]
 
-gul_dep = dependency('gul17', version : '> 2.6', fallback : ['gul17', 'libgul_dep'])
+gul_dep = dependency('gul17', fallback : ['gul17', 'libgul_dep'])
 
 deps = [
     dependency('threads'),

--- a/src/Executor.cc
+++ b/src/Executor.cc
@@ -4,7 +4,7 @@
  * \date   Created on May 30, 2022
  * \brief  Implementation of the Executor class.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,13 +22,13 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/cat.h>
+#include <gul17/cat.h>
 
 #include "lua_details.h"
 #include "sol/sol.hpp"
 #include "taskolib/Executor.h"
 
-using gul14::cat;
+using gul17::cat;
 using namespace std::literals;
 
 namespace task {
@@ -115,12 +115,12 @@ void Executor::launch_async_execution(Sequence& sequence, Context context,
                          std::move(context), comm_channel_, step_index);
 
     sequence.set_running(true);
-    sequence.set_error(gul14::nullopt);
+    sequence.set_error(std::nullopt);
 }
 
 void Executor::run_asynchronously(Sequence& sequence, Context context)
 {
-    launch_async_execution(sequence, context, gul14::nullopt);
+    launch_async_execution(sequence, context, std::nullopt);
 }
 
 void Executor::run_single_step_asynchronously(Sequence& sequence, Context context,

--- a/src/SequenceManager.cc
+++ b/src/SequenceManager.cc
@@ -4,7 +4,7 @@
  * \date    Created on July 22, 2022
  * \brief   Manage and control sequences.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,7 +25,7 @@
 #include <algorithm>
 #include <fstream>
 
-#include <gul14/gul.h>
+#include <gul17/gul.h>
 
 #include "deserialize_sequence.h"
 #include "internals.h"
@@ -36,7 +36,7 @@
 #include <libgit4cpp/Repository.h>
 
 using namespace std::literals::string_literals;
-using gul14::cat;
+using gul17::cat;
 
 namespace task {
 
@@ -88,7 +88,7 @@ void store_sequence_parameters(const std::filesystem::path& lua_file, const Sequ
 /// Extracted from High Level Controls Utility Library (DESY), file string_util.h/cc
 int hex2dec(const char c)
 {
-    static constexpr gul14::string_view table { "0123456789abcdef" };
+    static constexpr std::string_view table { "0123456789abcdef" };
     auto pos = table.find(c);
     if (pos == table.npos)
         return -1;
@@ -98,7 +98,7 @@ int hex2dec(const char c)
 
 /// Extracted from High Level Controls Utility Library (DESY), file string_util.h/cc
 // str must be at least 2 chars long; returns negative if conversion failed.
-int hex2dec_2chars(gul14::string_view str)
+int hex2dec_2chars(std::string_view str)
 {
     const int a = hex2dec(str[0]);
     const int b = hex2dec(str[1]);
@@ -108,7 +108,7 @@ int hex2dec_2chars(gul14::string_view str)
 }
 
 /// Extracted from High Level Controls Utility Library (DESY), file string_util.h/cc
-std::string unescape_filename_characters(gul14::string_view str)
+std::string unescape_filename_characters(std::string_view str)
 {
     std::string out;
     out.reserve(str.size());
@@ -159,7 +159,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
 
     const auto old_name = find_sequence_on_disk(original_uid, sequences).path;
 
-    auto ok = perform_commit(gul14::cat("Copy sequence ", old_name.string(), " to "),
+    auto ok = perform_commit(gul17::cat("Copy sequence ", old_name.string(), " to "),
         [this, &seq]() {
             return this->write_sequence_to_disk(seq);
         });
@@ -170,7 +170,7 @@ SequenceManager::copy_sequence(UniqueId original_uid, const SequenceName& new_na
 }
 
 Sequence
-SequenceManager::create_sequence(gul14::string_view label, SequenceName name)
+SequenceManager::create_sequence(std::string_view label, SequenceName name)
 {
     const auto sequences = list_sequences();
     const UniqueId unique_id = create_unique_id(sequences);
@@ -219,7 +219,7 @@ Sequence SequenceManager::import_sequence(const std::filesystem::path& path)
     const UniqueId new_unique_id = create_unique_id(list_sequences());
     seq.set_unique_id(new_unique_id);
 
-    auto ok = perform_commit(gul14::cat("Import sequence from ", path.string(), " to "),
+    auto ok = perform_commit(gul17::cat("Import sequence from ", path.string(), " to "),
         [this, &seq]() {
             return this->write_sequence_to_disk(seq);
         });
@@ -292,7 +292,7 @@ Sequence SequenceManager::load_sequence(const SequenceOnDisk& seq_on_disk) const
     for (auto const& entry : std::filesystem::directory_iterator{ path })
     {
         if (entry.is_regular_file()
-            and gul14::starts_with(entry.path().filename().string(), "step_"))
+            and gul17::starts_with(entry.path().filename().string(), "step_"))
         {
             steps.push_back(entry.path());
         }
@@ -312,7 +312,7 @@ Sequence SequenceManager::load_sequence(const SequenceOnDisk& seq_on_disk) const
     return seq;
 }
 
-SequenceName SequenceManager::make_sequence_name_from_label(gul14::string_view label)
+SequenceName SequenceManager::make_sequence_name_from_label(std::string_view label)
 {
     std::string name;
 
@@ -321,7 +321,7 @@ SequenceName SequenceManager::make_sequence_name_from_label(gul14::string_view l
 
     for (const auto c : label)
     {
-        if (gul14::contains(SequenceName::valid_characters, c))
+        if (gul17::contains(SequenceName::valid_characters, c))
             name.push_back(c);
         else
             name.push_back('_');
@@ -330,7 +330,7 @@ SequenceName SequenceManager::make_sequence_name_from_label(gul14::string_view l
     return SequenceName{ name };
 }
 
-gul14::optional<SequenceManager::SequenceOnDisk> SequenceManager::parse_folder_name(
+std::optional<SequenceManager::SequenceOnDisk> SequenceManager::parse_folder_name(
     const std::filesystem::path& folder)
 {
     const std::string str = unescape_filename_characters(folder.filename().string());
@@ -340,7 +340,7 @@ gul14::optional<SequenceManager::SequenceOnDisk> SequenceManager::parse_folder_n
     if (opening_bracket != std::string::npos && closing_bracket == str.size() - 1)
     {
         auto name = SequenceName::from_string(
-            gul14::trim(str.substr(0, opening_bracket)));
+            gul17::trim(str.substr(0, opening_bracket)));
         auto unique_id = UniqueId::from_string(
             str.substr(opening_bracket + 1, closing_bracket - opening_bracket - 1));
 
@@ -378,7 +378,7 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
     const auto old_seq_on_disk = find_sequence_on_disk(unique_id, sequences);
     const auto new_disk_name = make_sequence_filename(new_name, unique_id);
 
-    auto ok = perform_commit(gul14::cat("Rename ", old_seq_on_disk.path.string(), " to "),
+    auto ok = perform_commit(gul17::cat("Rename ", old_seq_on_disk.path.string(), " to "),
         [this, &old_seq_on_disk, &new_disk_name]() {
             const auto old_path = this->path_ / old_seq_on_disk.path;
             const auto new_path = this->path_ / new_disk_name;
@@ -386,7 +386,7 @@ void SequenceManager::rename_sequence(UniqueId unique_id, const SequenceName& ne
             std::filesystem::rename(old_path, new_path, error);
             if (error)
             {
-                throw Error{ gul14::cat("Cannot rename folder ", old_path.string(),
+                throw Error{ gul17::cat("Cannot rename folder ", old_path.string(),
                     " to ", new_path.string(), ": ", error.message()) };
             }
             return new_disk_name;
@@ -440,7 +440,7 @@ std::string SequenceManager::stage_files(const std::string& glob)
         if (elm.handling != "staged")
             continue;
         auto filename = std::filesystem::path{ elm.path_name }.filename();
-        git_msg = gul14::cat(git_msg, "\n- ", elm.changes, ": ", filename.c_str());
+        git_msg = gul17::cat(git_msg, "\n- ", elm.changes, ": ", filename.c_str());
     }
     return git_msg;
 }

--- a/src/SequenceName.cc
+++ b/src/SequenceName.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 26, 2023
  * \brief  Implementation of the SequenceName class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,22 +22,22 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/cat.h>
-#include <gul14/escape.h>
-#include <gul14/substring_checks.h>
+#include <gul17/cat.h>
+#include <gul17/escape.h>
+#include <gul17/substring_checks.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/SequenceName.h"
 
-using gul14::cat;
+using gul17::cat;
 
 namespace task {
 
-SequenceName::SequenceName(gul14::string_view str)
+SequenceName::SequenceName(std::string_view str)
     : str_{ check_validity(str) }
 {}
 
-gul14::string_view SequenceName::check_validity(gul14::string_view str)
+std::string_view SequenceName::check_validity(std::string_view str)
 {
     if (str.size() > max_length)
     {
@@ -45,19 +45,19 @@ gul14::string_view SequenceName::check_validity(gul14::string_view str)
             " bytes > ", max_length, " bytes"));
     }
 
-    if (str.find_first_not_of(valid_characters) != gul14::string_view::npos)
+    if (str.find_first_not_of(valid_characters) != std::string_view::npos)
     {
-        throw Error(cat("Sequence name '", gul14::escape(str),
+        throw Error(cat("Sequence name '", gul17::escape(str),
             "' contains invalid characters"));
     }
 
-    if (gul14::starts_with(str, '.'))
+    if (gul17::starts_with(str, '.'))
         throw Error(cat("A sequence name may not start with a period ('", str, "'"));
 
     return str;
 }
 
-gul14::optional<SequenceName> SequenceName::from_string(gul14::string_view str)
+std::optional<SequenceName> SequenceName::from_string(std::string_view str)
 {
     try
     {
@@ -69,7 +69,7 @@ gul14::optional<SequenceName> SequenceName::from_string(gul14::string_view str)
     }
 }
 
-const gul14::string_view SequenceName::valid_characters{
+const std::string_view SequenceName::valid_characters{
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_." };
 
 } // namespace task

--- a/src/Step.cc
+++ b/src/Step.cc
@@ -4,7 +4,7 @@
  * \date    Created on December 7, 2021
  * \brief   Implementation of the Step class.
  *
- * \copyright Copyright 2021-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,9 +22,9 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/cat.h>
-#include <gul14/finalizer.h>
-#include <gul14/trim.h>
+#include <gul17/cat.h>
+#include <gul17/finalizer.h>
+#include <gul17/trim.h>
 
 #include "internals.h"
 #include "lua_details.h"
@@ -35,7 +35,7 @@
 #include "taskolib/Step.h"
 
 using namespace std::literals;
-using gul14::cat;
+using gul17::cat;
 
 namespace {
 
@@ -130,7 +130,7 @@ bool Step::execute_impl(Context& context, CommChannel* comm,
     {
         const auto result = execute_lua_script(lua, context.step_setup_script);
         if (not result.has_value())
-            throw Error(gul14::cat("[setup] ", result.error()));
+            throw Error(gul17::cat("[setup] ", result.error()));
     }
 
     copy_used_variables_from_context_to_lua(context, lua);
@@ -169,7 +169,7 @@ bool Step::execute(Context& context, CommChannel* comm, OptionalStepIndex index,
 {
     const auto now = Clock::now();
     const auto set_is_running_to_false_after_execution =
-        gul14::finally([this]() { set_running(false); });
+        gul17::finally([this]() { set_running(false); });
 
     set_time_of_last_execution(now);
     set_running(true);
@@ -225,7 +225,7 @@ Step& Step::set_indentation_level(short level)
 
 Step& Step::set_label(const std::string& label)
 {
-    label_ = gul14::trim(label);
+    label_ = gul17::trim(label);
     set_time_of_last_modification(Clock::now());
     return *this;
 }

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 17, 2024
  * \brief  Implementation of the Tag class.
  *
- * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2024-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,22 +24,22 @@
 
 #include <ostream>
 
-#include <gul14/cat.h>
-#include <gul14/escape.h>
-#include <gul14/substring_checks.h>
+#include <gul17/cat.h>
+#include <gul17/escape.h>
+#include <gul17/substring_checks.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/Tag.h"
 
-using gul14::cat;
+using gul17::cat;
 
 namespace task {
 
-Tag::Tag(gul14::string_view name)
-    : name_{ check_validity(gul14::lowercase_ascii(name)) }
+Tag::Tag(std::string_view name)
+    : name_{ check_validity(gul17::lowercase_ascii(name)) }
 {}
 
-gul14::string_view Tag::check_validity(gul14::string_view name)
+std::string_view Tag::check_validity(std::string_view name)
 {
     if (name.empty())
         throw Error("Tag must not be empty");
@@ -50,13 +50,13 @@ gul14::string_view Tag::check_validity(gul14::string_view name)
             max_length, " bytes"));
     }
 
-    if (name.find_first_not_of(valid_characters) != gul14::string_view::npos)
-        throw Error(cat("Tag '", gul14::escape(name), "' contains invalid characters"));
+    if (name.find_first_not_of(valid_characters) != std::string_view::npos)
+        throw Error(cat("Tag '", gul17::escape(name), "' contains invalid characters"));
 
     return name;
 }
 
-const gul14::string_view Tag::valid_characters{ "abcdefghijklmnopqrstuvwxyz0123456789-" };
+const std::string_view Tag::valid_characters{ "abcdefghijklmnopqrstuvwxyz0123456789-" };
 
 std::ostream& operator<<(std::ostream& stream, const Tag& tag)
 {

--- a/src/UniqueId.cc
+++ b/src/UniqueId.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 26, 2023
  * \brief  Implementation of the UniqueId class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,9 +24,9 @@
 
 #include <charconv>
 
-#include <gul14/cat.h>
-#include <gul14/escape.h>
-#include <gul14/string_util.h>
+#include <gul17/cat.h>
+#include <gul17/escape.h>
+#include <gul17/string_util.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/UniqueId.h"
@@ -45,7 +45,7 @@ UniqueId::UniqueId(ValueType id)
     : id_{ id }
 {}
 
-gul14::optional<UniqueId> UniqueId::from_string(gul14::string_view str)
+std::optional<UniqueId> UniqueId::from_string(std::string_view str)
 {
     if (str.empty() || str.size() > sizeof(ValueType) * 2)
         return {};
@@ -63,7 +63,7 @@ thread_local std::mt19937_64 UniqueId::random_number_generator_{ std::random_dev
 
 std::string to_string(UniqueId uid)
 {
-    return gul14::hex_string(uid.id_);
+    return gul17::hex_string(uid.id_);
 }
 
 } // namespace task

--- a/src/VariableName.cc
+++ b/src/VariableName.cc
@@ -4,7 +4,7 @@
  * \date   Created on January 6, 2022
  * \brief  Implementation of the VariableName class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,11 +24,13 @@
 
 #include <algorithm>
 #include <cctype>
-#include <gul14/cat.h>
+
+#include <gul17/cat.h>
+
 #include "taskolib/exceptions.h"
 #include "taskolib/VariableName.h"
 
-using gul14::cat;
+using gul17::cat;
 
 namespace task {
 
@@ -36,7 +38,7 @@ namespace task {
 namespace {
 
 // Check that the given name is a valid variable name or throw a task::Error.
-void check_name(gul14::string_view name)
+void check_name(std::string_view name)
 {
     if (name.empty())
         throw Error("A variable name may not be empty");
@@ -78,9 +80,9 @@ VariableName::VariableName(std::string&& name)
     name_ = std::move(name);
 }
 
-VariableName& VariableName::operator+=(gul14::string_view suffix)
+VariableName& VariableName::operator+=(std::string_view suffix)
 {
-    std::string new_name = name_ + suffix;
+    std::string new_name = cat(name_, suffix);
 
     check_name(new_name);
 

--- a/src/deserialize_sequence.cc
+++ b/src/deserialize_sequence.cc
@@ -4,7 +4,7 @@
  * \date    Created on May 24, 2022
  * \brief   Deserialize Sequence and Steps from storage hardware.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -32,14 +32,14 @@
 #include <string>
 #include <vector>
 
-#include <gul14/gul.h>
+#include <gul17/gul.h>
 
 #include "deserialize_sequence.h"
 #include "internals.h"
 #include "taskolib/hash_string.h"
 
-using gul14::cat;
-using gul14::escape;
+using gul17::cat;
+using gul17::escape;
 
 namespace task {
 
@@ -53,27 +53,27 @@ namespace {
  * " -- Comment" -> ["", " -- Comment"]
  * "  something" -> ["", "  something"]
  */
-std::pair<gul14::string_view, gul14::string_view>
-extract_keyword(const gul14::string_view line)
+std::pair<std::string_view, std::string_view>
+extract_keyword(const std::string_view line)
 {
-    auto remainder = gul14::trim_left_sv(line);
+    auto remainder = gul17::trim_left_sv(line);
 
-    if (not gul14::starts_with(remainder, "-- "))
+    if (not gul17::starts_with(remainder, "-- "))
         return {{}, line};
 
     auto found_value = remainder.find(":");
-    if (found_value == gul14::string_view::npos)
+    if (found_value == std::string_view::npos)
         return {{}, line};
 
-    auto keyword = gul14::trim_sv(remainder.substr(3, found_value - 3)); // 3: length of "-- "
+    auto keyword = gul17::trim_sv(remainder.substr(3, found_value - 3)); // 3: length of "-- "
     remainder.remove_prefix(found_value + 1); // incl the ":"
 
     return { keyword, remainder };
 }
 
-void extract_type(gul14::string_view extract, Step& step)
+void extract_type(std::string_view extract, Step& step)
 {
-    auto keyword = gul14::trim_sv(extract);
+    auto keyword = gul17::trim_sv(extract);
 
     switch(hash_djb2a({keyword.data(), keyword.size()}))
     {
@@ -94,28 +94,28 @@ void extract_type(gul14::string_view extract, Step& step)
         case "end"_sh:
             step.set_type(Step::type_end); break;
         default:
-            throw Error(gul14::cat("type: unable to parse (\"", escape(keyword), "\")"));
+            throw Error(gul17::cat("type: unable to parse (\"", escape(keyword), "\")"));
     }
 }
 
-void extract_label(gul14::string_view extract, Step& step)
+void extract_label(std::string_view extract, Step& step)
 {
-    step.set_label(gul14::unescape(gul14::trim_sv(extract)));
+    step.set_label(gul17::unescape(gul17::trim_sv(extract)));
 }
 
-void extract_context_variable_names(gul14::string_view extract, Step& step)
+void extract_context_variable_names(std::string_view extract, Step& step)
 {
-    extract = gul14::trim_sv(extract);
-    if (not gul14::starts_with(extract, "["))
+    extract = gul17::trim_sv(extract);
+    if (not gul17::starts_with(extract, "["))
         throw Error("context variable names: cannot find leading '['");
     extract.remove_prefix(1);
 
     auto end = extract.find("]");
-    if (end == gul14::string_view::npos)
+    if (end == std::string_view::npos)
         throw Error("context variable names: cannot find trailing ']'");
     VariableNames variableNames{};
-    for (auto variable: gul14::split(extract.substr(0, end), std::regex{"[ \t]*,[ \t]*"})) {
-        variable = gul14::trim(variable);
+    for (auto variable: gul17::split(extract.substr(0, end), std::regex{"[ \t]*,[ \t]*"})) {
+        variable = gul17::trim(variable);
         if (not variable.empty())
             variableNames.emplace(variable);
     }
@@ -123,19 +123,19 @@ void extract_context_variable_names(gul14::string_view extract, Step& step)
         step.set_used_context_variable_names(variableNames);
 }
 
-TimePoint extract_time(const std::string& issue, gul14::string_view extract)
+TimePoint extract_time(const std::string& issue, std::string_view extract)
 {
     std::tm t;
 
     if (strptime(std::string{ extract }.c_str(), "%Y-%m-%d %H:%M:%S",&t) == nullptr)
-        throw Error(gul14::cat(issue, ": unable to parse time (\"", escape(extract), "\")"));
+        throw Error(gul17::cat(issue, ": unable to parse time (\"", escape(extract), "\")"));
     t.tm_isdst = -1; // Daylight Saving Time (DST) is unknown -> use local time zone
     auto convert = std::mktime(&t);
 
     return TimePoint::clock::from_time_t(convert);
 }
 
-void extract_time_of_last_execution(gul14::string_view extract, Step& step)
+void extract_time_of_last_execution(std::string_view extract, Step& step)
 {
     step.set_time_of_last_execution(extract_time("time of last execution", extract));
 }
@@ -161,7 +161,7 @@ std::istream& operator>>(std::istream& stream, Step& step)
             continue;
         }
         auto [keyword, remaining_line] = extract_keyword(line);
-        if (keyword.empty() && gul14::trim_sv(remaining_line).empty()) // load_script is false -> nothing useful
+        if (keyword.empty() && gul17::trim_sv(remaining_line).empty()) // load_script is false -> nothing useful
             continue;
 
         const auto keyword_hash = hash_djb2a(keyword);
@@ -169,7 +169,7 @@ std::istream& operator>>(std::istream& stream, Step& step)
         // validate multiple keyword declaration
         if (encountered_keywords.count(keyword_hash))
         {
-            throw Error(gul14::cat("Syntax error: Encountered keyword '", keyword,
+            throw Error(gul17::cat("Syntax error: Encountered keyword '", keyword,
                                    "' multiple times"));
         }
         encountered_keywords.insert(keyword_hash);
@@ -217,10 +217,10 @@ std::istream& operator>>(std::istream& stream, Step& step)
     }
 
     if (stream.bad())
-        throw Error(gul14::cat("I/O error: serious error on file system (bad flag is set)"));
+        throw Error(gul17::cat("I/O error: serious error on file system (bad flag is set)"));
     // need to get !eof (eof indicates that also the fail bit is set)
     else if (not stream.eof() and stream.fail())
-        throw Error(gul14::cat("I/O error: failure on loading step"));
+        throw Error(gul17::cat("I/O error: failure on loading step"));
 
     if (not has_type) // sanity check: missing type
         throw Error("Step must have type declaration");
@@ -250,7 +250,7 @@ Step load_step(const std::filesystem::path& lua_file)
     std::ifstream stream(lua_file);
 
     if (not stream.is_open())
-        throw Error(gul14::cat("I/O error: unable to open file \"", escape(lua_file.string()), '"'));
+        throw Error(gul17::cat("I/O error: unable to open file \"", escape(lua_file.string()), '"'));
 
     stream >> step; // RAII closes the stream (let the destructor do the job)
 
@@ -260,7 +260,7 @@ Step load_step(const std::filesystem::path& lua_file)
 void load_sequence_parameters(const std::filesystem::path& folder, Sequence& sequence)
 {
     if (not std::filesystem::exists(folder))
-        throw Error(gul14::cat("Folder does not exist: \"", escape(folder.string()), '"'));
+        throw Error(gul17::cat("Folder does not exist: \"", escape(folder.string()), '"'));
 
     auto stream = std::ifstream(folder / sequence_lua_filename);
 
@@ -271,19 +271,19 @@ void load_sequence_parameters(const std::filesystem::path& folder, Sequence& seq
     {
         while(std::getline(stream, line, '\n'))
         {
-            auto keyword = gul14::trim_left_sv(line);
+            auto keyword = gul17::trim_left_sv(line);
 
-            if (gul14::starts_with(keyword, "-- maintainers:"))
+            if (gul17::starts_with(keyword, "-- maintainers:"))
                 sequence.set_maintainers(keyword.substr(15));
-            else if (gul14::starts_with(keyword, "-- label:"))
-                sequence.set_label(gul14::trim_sv(keyword.substr(9)));
-            else if (gul14::starts_with(keyword, "-- timeout:"))
+            else if (gul17::starts_with(keyword, "-- label:"))
+                sequence.set_label(gul17::trim_sv(keyword.substr(9)));
+            else if (gul17::starts_with(keyword, "-- timeout:"))
                 sequence.set_timeout(parse_timeout(keyword.substr(11)));
-            else if (gul14::starts_with(keyword, "-- tags:"))
+            else if (gul17::starts_with(keyword, "-- tags:"))
                 sequence.set_tags(parse_tags(keyword.substr(8)));
-            else if (gul14::starts_with(keyword, "-- autorun:"))
+            else if (gul17::starts_with(keyword, "-- autorun:"))
                 sequence.set_autorun(parse_bool(keyword.substr(11)));
-            else if (gul14::starts_with(keyword, "-- disabled:"))
+            else if (gul17::starts_with(keyword, "-- disabled:"))
                 sequence.set_disabled(parse_bool(keyword.substr(12)));
             else
                 step_setup_script += (line + '\n');
@@ -293,36 +293,36 @@ void load_sequence_parameters(const std::filesystem::path& folder, Sequence& seq
     }
 }
 
-std::vector<Tag> parse_tags(gul14::string_view str)
+std::vector<Tag> parse_tags(std::string_view str)
 {
-    const auto tokens = gul14::tokenize_sv(str);
+    const auto tokens = gul17::tokenize_sv(str);
 
     std::vector<Tag> tags(tokens.size());
     std::transform(tokens.begin(), tokens.end(), tags.begin(),
-                   [](gul14::string_view token) { return Tag{ token }; });
+                   [](std::string_view token) { return Tag{ token }; });
     return tags;
 }
 
-bool parse_bool(gul14::string_view str)
+bool parse_bool(std::string_view str)
 {
-    auto bool_expression{gul14::trim_sv(str)};
+    auto bool_expression{gul17::trim_sv(str)};
     if (bool_expression == "true" )
         return true;
     else if (bool_expression == "false")
         return false;
-    throw Error(gul14::cat("Cannot parse bool expression from \"", escape(str), '"'));
+    throw Error(gul17::cat("Cannot parse bool expression from \"", escape(str), '"'));
 }
 
-Timeout parse_timeout(gul14::string_view str)
+Timeout parse_timeout(std::string_view str)
 {
-    str = gul14::trim_sv(str);
+    str = gul17::trim_sv(str);
 
-    if (gul14::equals_nocase(str, "infinite"))
+    if (gul17::equals_nocase(str, "infinite"))
         return Timeout::infinity();
 
-    const auto maybe_msec = gul14::to_number<unsigned long long>(str);
+    const auto maybe_msec = gul17::to_number<unsigned long long>(str);
     if (!maybe_msec)
-        throw Error(gul14::cat("Cannot parse timeout from \"", escape(str), '"'));
+        throw Error(gul17::cat("Cannot parse timeout from \"", escape(str), '"'));
 
     return Timeout{ std::chrono::milliseconds{ *maybe_msec } };
 }

--- a/src/deserialize_sequence.h
+++ b/src/deserialize_sequence.h
@@ -4,7 +4,7 @@
  * \date    Created on May 24, 2022
  * \brief   Deserialize Sequence and Steps from storage hardware.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,9 +27,8 @@
 
 #include <filesystem>
 #include <iostream>
+#include <string_view>
 #include <vector>
-
-#include <gul14/string_view.h>
 
 #include "taskolib/Sequence.h"
 #include "taskolib/Step.h"
@@ -120,12 +119,12 @@ void load_sequence_parameters(const std::filesystem::path& folder, Sequence& seq
  *
  * \exception Error is thrown if a tag with an invalid name is encountered.
  */
-std::vector<Tag> parse_tags(gul14::string_view str);
+std::vector<Tag> parse_tags(std::string_view str);
 
 /**
  * Parse a bool expression from a string.
  */
-bool parse_bool(gul14::string_view str);
+bool parse_bool(std::string_view str);
 
 /**
  * Parse a string into a Timeout value.
@@ -135,7 +134,7 @@ bool parse_bool(gul14::string_view str);
  *
  * \exception Error is thrown if the string does not represent a valid Timeout.
  */
-Timeout parse_timeout(gul14::string_view str);
+Timeout parse_timeout(std::string_view str);
 
 } // namespace task
 

--- a/src/execute_lua_script.cc
+++ b/src/execute_lua_script.cc
@@ -4,7 +4,7 @@
  * \date   Created on November 15, 2022
  * \brief  Implementation of execute_lua_script() and load_lua_script().
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,9 +23,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <stdexcept>
+#include <string_view>
 
-#include <gul14/replace.h>
-#include <gul14/string_view.h>
+#include <gul17/replace.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/execute_lua_script.h"
@@ -35,9 +35,9 @@ namespace task {
 namespace {
 
 const std::string anchor = u8"\u2693";
-constexpr gul14::string_view chunk_prefix{ u8"[string \"\u2693\"]:" };
+constexpr std::string_view chunk_prefix{ u8"[string \"\u2693\"]:" };
 
-std::string process_msg(gul14::string_view msg)
+std::string process_msg(std::string_view msg)
 {
     // If C++ code is called by Lua and throws an exception that is not derived
     // from std::exception, the exception is not intercepted by the Sol
@@ -52,12 +52,12 @@ std::string process_msg(gul14::string_view msg)
         return "Unknown exception";
     }
 
-    return gul14::replace(msg, chunk_prefix, "");
+    return gul17::replace(msg, chunk_prefix, "");
 }
 
 } // anonymous namespace
 
-gul14::expected<sol::object, std::string>
+gul17::expected<sol::object, std::string>
 execute_lua_script(sol::state& lua, sol::string_view script)
 {
     try
@@ -68,29 +68,29 @@ execute_lua_script(sol::state& lua, sol::string_view script)
         if (!protected_result.valid())
         {
             sol::error err = protected_result;
-            return gul14::unexpected(process_msg(err.what()));
+            return gul17::unexpected(process_msg(err.what()));
         }
 
         return static_cast<sol::object>(protected_result);
     }
     catch(const std::exception& e)
     {
-        return gul14::unexpected(process_msg(e.what()));
+        return gul17::unexpected(process_msg(e.what()));
     }
     catch(...)
     {
-        return gul14::unexpected("Unknown C++ exception");
+        return gul17::unexpected("Unknown C++ exception");
     }
 }
 
-gul14::expected<sol::load_result, std::string>
+gul17::expected<sol::load_result, std::string>
 load_lua_script(sol::state& lua, sol::string_view script)
 {
     sol::load_result result = lua.load(script, anchor);
     if (result.valid())
         return result;
 
-    return gul14::unexpected(static_cast<sol::error>(result).what());
+    return gul17::unexpected(static_cast<sol::error>(result).what());
 }
 
 } // namespace task

--- a/src/internals.cc
+++ b/src/internals.cc
@@ -4,7 +4,7 @@
  * \date   Created on August 30, 2022
  * \brief  Definition of internal constants and functions.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,10 +22,10 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/cat.h>
-#include <gul14/join_split.h>
-#include <gul14/replace.h>
-#include <gul14/SmallVector.h>
+#include <gul17/cat.h>
+#include <gul17/join_split.h>
+#include <gul17/replace.h>
+#include <gul17/SmallVector.h>
 
 #include "internals.h"
 
@@ -33,18 +33,18 @@
 
 namespace task {
 
-const gul14::string_view abort_marker{ u8"\U0001F6D1ABORT\U0001F6D1" };
+const std::string_view abort_marker{ u8"\U0001F6D1ABORT\U0001F6D1" };
 
-std::string beautify_message(gul14::string_view msg)
+std::string beautify_message(std::string_view msg)
 {
     // Replace the Lua stack trace header with a more friendly one including a big UTF-8
     // bullet point ("black circle") that visually separates the main message text from
     // the stack trace.
-    return gul14::replace(msg, "\nstack traceback:\n",
+    return gul17::replace(msg, "\nstack traceback:\n",
         u8"\n\u25cf Stack traceback:\n");
 }
 
-void check_for_control_characters(gul14::string_view str)
+void check_for_control_characters(std::string_view str)
 {
     auto count = std::count_if(str.cbegin(), str.cend(),
         [](unsigned char c) -> bool { return std::iscntrl(c); });
@@ -53,9 +53,9 @@ void check_for_control_characters(gul14::string_view str)
         throw Error("String should not contain any control character.");
 }
 
-std::pair<std::string, ErrorCause> remove_abort_markers(gul14::string_view error_message)
+std::pair<std::string, ErrorCause> remove_abort_markers(std::string_view error_message)
 {
-    const auto tokens = gul14::split<gul14::SmallVector<gul14::string_view, 3>>(
+    const auto tokens = gul17::split<gul17::SmallVector<std::string_view, 3>>(
         error_message, abort_marker);
 
     std::string msg;
@@ -67,7 +67,7 @@ std::pair<std::string, ErrorCause> remove_abort_markers(gul14::string_view error
         return std::make_pair(beautify_message(error_message),
             ErrorCause::uncaught_error);
     case 2: // one marker
-        msg = beautify_message(gul14::cat(tokens[0], tokens[1]));
+        msg = beautify_message(gul17::cat(tokens[0], tokens[1]));
         break;
     case 3: // The real error message is between the first 2 abort markers.
     default:

--- a/src/internals.h
+++ b/src/internals.h
@@ -4,7 +4,7 @@
  * \date   Created on August 30, 2022
  * \brief  Declaration of internal constants and functions.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -28,7 +28,7 @@
 #include <string>
 #include <utility>
 
-#include <gul14/string_view.h>
+#include <string_view>
 
 namespace task {
 
@@ -42,14 +42,14 @@ const char sequence_lua_filename[] = "sequence.lua";
  * A marker string (the word "ABORT" surrounded by Unicode stop signs) whose presence
  * anywhere in an error message signals that the execution of a script should be stopped.
  */
-extern const gul14::string_view abort_marker;
+extern const std::string_view abort_marker;
 
 /**
  * Throw an exception if the string contains control characters.
  *
  * \exception Error is thrown if the string contains any control characters.
  */
-void check_for_control_characters(gul14::string_view str);
+void check_for_control_characters(std::string_view str);
 
 /**
  * Remove abort markers from the given error message, beautify it, and determine the cause
@@ -77,7 +77,7 @@ void check_for_control_characters(gul14::string_view str);
  * \returns a pair consisting of the (possibly) modified error message and of an
  *          ErrorCause.
  */
-std::pair<std::string, ErrorCause> remove_abort_markers(gul14::string_view error_message);
+std::pair<std::string, ErrorCause> remove_abort_markers(std::string_view error_message);
 
 } // namespace task
 

--- a/src/lua_details.cc
+++ b/src/lua_details.cc
@@ -4,7 +4,7 @@
  * \date   Created on June 15, 2022
  * \brief  Implementation of free functions dealing with Lua specifics.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,7 +24,7 @@
 
 #include <limits>
 
-#include <gul14/gul.h>
+#include <gul17/gul.h>
 
 #include "internals.h"
 #include "lua_details.h"
@@ -32,7 +32,7 @@
 #include "taskolib/CommChannel.h"
 #include "taskolib/exceptions.h"
 
-using gul14::cat;
+using gul17::cat;
 
 namespace {
 
@@ -64,7 +64,7 @@ void abort_script_with_error(lua_State* lua_state, const std::string& msg)
     // The [ABORT] marker ("ABORT" surrounded by two Unicode stop signs) marks this error
     // as one that can not be caught by CATCH blocks.
     // We store the error message in the registry...
-    registry[abort_error_message_key] = gul14::cat(abort_marker, msg, abort_marker);
+    registry[abort_error_message_key] = gul17::cat(abort_marker, msg, abort_marker);
 
     // ... and call the abort hook which raises a Lua error with the message from the
     // registry.
@@ -168,7 +168,7 @@ OptionalStepIndex get_step_idx_from_registry(lua_State* lua_state)
 
     // The step index stored in the Lua registry is negative if it is not available.
     if (*maybe_lua_step_idx < 0)
-        return gul14::nullopt;
+        return std::nullopt;
 
     return static_cast<StepIndex>(*maybe_lua_step_idx);
 }
@@ -262,13 +262,13 @@ void print_fct(sol::this_state sol, sol::variadic_args va)
 
     try
     {
-        gul14::SmallVector<std::string, 8> stringified_args;
+        gul17::SmallVector<std::string, 8> stringified_args;
         stringified_args.reserve(va.size());
 
         for (auto v : va)
             stringified_args.push_back(tostring(v));
 
-        send_message(Message::Type::output, gul14::join(stringified_args, "\t") + "\n",
+        send_message(Message::Type::output, gul17::join(stringified_args, "\t") + "\n",
                      Clock::now(), get_step_idx_from_registry(sol),
                      get_context_from_registry(sol),
                      get_comm_channel_ptr_from_registry(sol));
@@ -281,12 +281,12 @@ void print_fct(sol::this_state sol, sol::variadic_args va)
 
 void sleep_fct(double seconds, sol::this_state sol)
 {
-    auto t0 = gul14::tic();
-    while (gul14::toc(t0) < seconds)
+    auto t0 = gul17::tic();
+    while (gul17::toc(t0) < seconds)
     {
         hook_check_timeout_and_termination_request(sol, nullptr);
-        double sec = gul14::clamp(seconds - gul14::toc(t0), 0.0, 0.01);
-        gul14::sleep(sec);
+        double sec = gul17::clamp(seconds - gul17::toc(t0), 0.0, 0.01);
+        gul17::sleep(sec);
     }
 }
 

--- a/src/send_message.cc
+++ b/src/send_message.cc
@@ -4,7 +4,7 @@
  * \date   Created on January 30, 2023, based on older code
  * \brief  Declaration of the send_message() function.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,7 +26,7 @@
 
 namespace task {
 
-void send_message(Message::Type type, gul14::string_view text, TimePoint timestamp,
+void send_message(Message::Type type, std::string_view text, TimePoint timestamp,
                   OptionalStepIndex index, const Context& context,
                   CommChannel* comm_channel)
 {

--- a/src/send_message.h
+++ b/src/send_message.h
@@ -4,7 +4,7 @@
  * \date   Created on January 30, 2023, based on older code
  * \brief  Declaration of the send_message() function.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,7 +25,7 @@
 #ifndef TASKOLIB_SEND_MESSAGE_H_
 #define TASKOLIB_SEND_MESSAGE_H_
 
-#include <gul14/string_view.h>
+#include <string_view>
 
 #include "taskolib/CommChannel.h"
 #include "taskolib/Context.h"
@@ -47,7 +47,7 @@ namespace task {
  *                      function does not attempt to push the message into any message
  *                      queue.
  */
-void send_message(Message::Type type, gul14::string_view text, TimePoint timestamp,
+void send_message(Message::Type type, std::string_view text, TimePoint timestamp,
                   OptionalStepIndex index, const Context& context,
                   CommChannel* comm_channel = nullptr);
 

--- a/src/serialize_sequence.cc
+++ b/src/serialize_sequence.cc
@@ -4,7 +4,7 @@
  * \date   Created on May 06, 2022
  * \brief  Implementation of the store_sequence() free function.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,12 +25,12 @@
 #include <fstream>
 #include <sstream>
 
-#include <gul14/gul.h>
+#include <gul17/gul.h>
 
 #include "internals.h"
 #include "serialize_sequence.h"
 
-using gul14::cat;
+using gul17::cat;
 
 namespace task {
 
@@ -58,10 +58,10 @@ std::ostream& operator<<(std::ostream& stream, const Step& step)
     //    << LUA_VERSION_MAJOR << ", Sol2 version: " << SOL_VERSION_STRING << '\n';
 
     stream << "-- type: " << to_string(step.get_type()) << '\n';
-    stream << "-- label: " << gul14::escape(step.get_label()) << '\n';
+    stream << "-- label: " << gul17::escape(step.get_label()) << '\n';
 
     stream << "-- use context variable names: [";
-    stream << gul14::join(step.get_used_context_variable_names(), ", ") << "]\n";
+    stream << gul17::join(step.get_used_context_variable_names(), ", ") << "]\n";
 
     auto modify = TimePoint::clock::to_time_t(step.get_time_of_last_modification());
     stream << "-- time of last modification: "
@@ -96,7 +96,7 @@ void store_step(const std::filesystem::path& lua_file, const Step& step)
     std::ofstream stream(lua_file);
 
     if (not stream.is_open())
-        throw Error(gul14::cat("I/O error: unable to open file (", lua_file.string(), ")"));
+        throw Error(gul17::cat("I/O error: unable to open file (", lua_file.string(), ")"));
 
     stream << step; // RAII closes the stream (let the destructor do the job)
 }

--- a/src/serialize_sequence.h
+++ b/src/serialize_sequence.h
@@ -4,7 +4,7 @@
  * \date   Created on May 6, 2022
  * \brief  Serialize Sequence and Steps on storage hardware.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -27,8 +27,7 @@
 
 #include <filesystem>
 #include <iostream>
-
-#include <gul14/string_view.h>
+#include <string_view>
 
 #include "taskolib/Sequence.h"
 #include "taskolib/Step.h"

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,9 +1,11 @@
-[wrap-git]
-directory = catch2
-url = https://github.com/catchorg/Catch2.git
-revision = v3.8.0
+[wrap-file]
+directory = Catch2-3.8.1
+source_url = https://github.com/catchorg/Catch2/archive/v3.8.1.tar.gz
+source_filename = Catch2-3.8.1.tar.gz
+source_hash = 18b3f70ac80fccc340d8c6ff0f339b2ae64944782f8d2fca2bd705cf47cadb79
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.8.1-1/Catch2-3.8.1.tar.gz
+wrapdb_version = 3.8.1-1
 
 [provide]
-dependency_names = catch2, catch2_with_main
 catch2 = catch2_dep
-catch2_with_main = catch2_with_main_dep
+catch2-with-main = catch2_with_main_dep

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,0 +1,9 @@
+[wrap-git]
+directory = catch2
+url = https://github.com/catchorg/Catch2.git
+revision = v3.8.0
+
+[provide]
+dependency_names = catch2, catch2_with_main
+catch2 = catch2_dep
+catch2_with_main = catch2_with_main_dep

--- a/subprojects/gul17.wrap
+++ b/subprojects/gul17.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+directory = gul17
+url = https://github.com/gul-cpp/gul17.git
+revision = main
+
+[provide]
+dependency_names = gul17
+gul17 = libgul_dep

--- a/subprojects/libgul14.wrap
+++ b/subprojects/libgul14.wrap
@@ -1,7 +1,0 @@
-[wrap-git]
-directory = libgul14
-url = https://github.com/gul-cpp/gul14.git
-revision = main
-
-[provide]
-libgul14 = libgul_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,7 +29,10 @@ test_src = files(
 test('all',
     executable(meson.project_name() + '_test',
         test_src,
-        dependencies : taskolib_dep,
+        dependencies : [
+            taskolib_dep,
+            dependency('catch2'),
+        ],
     ),
     workdir : meson.current_build_dir(),
     timeout : 10,
@@ -40,7 +43,11 @@ if fmt_dep.found()
     test('format',
         executable(meson.project_name() + '_format_test',
             [ 'test_format.cc', 'test_main.cc', ],
-            dependencies : [ taskolib_dep, dependency('fmt'), ],
+            dependencies : [
+                taskolib_dep,
+                dependency('catch2'),
+                dependency('fmt'),
+            ],
         ),
         timeout : 10,
     )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -24,14 +24,20 @@ test_src = files(
     #'tests/test_format.cc' needs fmt{} library
 )
 
+catch2_dep = dependency(
+    'catch2',
+    version : '>=3.4.1',
+    fallback : [ 'catch2', 'catch2_dep' ]
+)
+
 # The tests are executed in the build dir to avoid pollution of the git repository with
 # the test executable's output files
 test('all',
     executable(meson.project_name() + '_test',
         test_src,
         dependencies : [
+            catch2_dep,
             taskolib_dep,
-            dependency('catch2'),
         ],
     ),
     workdir : meson.current_build_dir(),
@@ -44,8 +50,8 @@ if fmt_dep.found()
         executable(meson.project_name() + '_format_test',
             [ 'test_format.cc', 'test_main.cc', ],
             dependencies : [
+                catch2_dep,
                 taskolib_dep,
-                dependency('catch2'),
                 dependency('fmt'),
             ],
         ),

--- a/tests/test_CommChannel.cc
+++ b/tests/test_CommChannel.cc
@@ -4,7 +4,7 @@
  * \date   Created on June 8, 2022
  * \brief  Test suite for the CommChannel struct.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,7 +24,7 @@
 
 #include <type_traits>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "taskolib/CommChannel.h"
 

--- a/tests/test_Context.cc
+++ b/tests/test_Context.cc
@@ -4,7 +4,7 @@
  * \date   Created on December 20, 2021
  * \brief  Test suite for the Context class.
  *
- * \copyright Copyright 2021-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,8 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
+
 #include "taskolib/Context.h"
 
 using namespace std::literals;

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -1,10 +1,10 @@
 /**
- * \file   test_Executor.cc
- * \author Lars Fröhlich, Marcus Walla
- * \date   Created on May 30, 2022
- * \brief  Test suite for the Executor class.
+ * \file    test_Executor.cc
+ * \authors Lars Fröhlich, Marcus Walla
+ * \date    Created on May 30, 2022
+ * \brief   Test suite for the Executor class.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,14 +22,16 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <gul14/substring_checks.h>
 #include <gul14/time_util.h>
+
 #include "taskolib/Executor.h"
 
 using namespace task;
 using namespace std::literals;
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("Executor: Constructor", "[Executor]")
 {
@@ -243,7 +245,7 @@ TEST_CASE("Executor: run_single_step_asynchronously()", "[Executor]")
         REQUIRE(std::get<VarInteger>(vars["a"]) == 1);
 
         REQUIRE(sequence.get_error().has_value() == true);
-        REQUIRE_THAT(sequence.get_error()->what(), Contains("Waldeinsamkeit"));
+        REQUIRE_THAT(sequence.get_error()->what(), ContainsSubstring("Waldeinsamkeit"));
         REQUIRE(sequence.get_error()->get_index().has_value() == true);
         REQUIRE(sequence.get_error()->get_index().value() == 0);
     }
@@ -529,7 +531,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
     // I. direct execution
     auto maybe_error = seq.execute(ctx, nullptr);
     REQUIRE(maybe_error.has_value() == true);
-    REQUIRE_THAT(maybe_error->what(), Contains("Rainbows"));
+    REQUIRE_THAT(maybe_error->what(), ContainsSubstring("Rainbows"));
 
     // II. run async
     Executor executor{ };
@@ -543,7 +545,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
     REQUIRE(executor.update(seq) == false);
 
     REQUIRE(seq.get_error().has_value() == true);
-    REQUIRE_THAT(seq.get_error()->what(), Contains("Rainbows"));
+    REQUIRE_THAT(seq.get_error()->what(), ContainsSubstring("Rainbows"));
 }
 
 TEST_CASE("Executor: Message callbacks", "[execute_sequence]")

--- a/tests/test_Executor.cc
+++ b/tests/test_Executor.cc
@@ -24,8 +24,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <gul14/substring_checks.h>
-#include <gul14/time_util.h>
+#include <gul17/substring_checks.h>
+#include <gul17/time_util.h>
 
 #include "taskolib/Executor.h"
 
@@ -77,7 +77,7 @@ TEST_CASE("Executor: run_asynchronously()", "[Executor]")
     for (const auto& step : sequence)
         REQUIRE(step.is_running() == false);
 
-    const auto t0 = gul14::tic();
+    const auto t0 = gul17::tic();
 
     // Start the sequence in a separate thread
     executor.run_asynchronously(sequence, context);
@@ -101,13 +101,13 @@ TEST_CASE("Executor: run_asynchronously()", "[Executor]")
             std::any_of(sequence.begin(), sequence.end(),
                         [](const Step& s) { return s.is_running(); });
 
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
     }
 
     // We must have seen a step marked as "is_running" at least once during execution.
     REQUIRE(have_seen_running_step == true);
 
-    REQUIRE(gul14::toc(t0) >= 0.02);
+    REQUIRE(gul17::toc(t0) >= 0.02);
 
     // Thread has now finished. As long as we do not start another one, update() keeps
     // returning false.
@@ -145,7 +145,7 @@ TEST_CASE("Executor: run_asynchronously(), failing sequence", "[Executor]")
 
     // Process messages as long as the thread is running
     while (executor.update(sequence))
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
 
     // Thread has now finished. As long as we do not start another one, update() keeps
     // returning false.
@@ -180,7 +180,7 @@ TEST_CASE("Executor: run_single_step_asynchronously()", "[Executor]")
 
     SECTION("Running a step successfully")
     {
-        const auto t0 = gul14::tic();
+        const auto t0 = gul17::tic();
 
         // Invalid step index must throw
         REQUIRE_THROWS_AS(
@@ -205,10 +205,10 @@ TEST_CASE("Executor: run_single_step_asynchronously()", "[Executor]")
         {
             REQUIRE(sequence[0].is_running() == false);
             step2_seen_running |= sequence[1].is_running();
-            gul14::sleep(5ms);
+            gul17::sleep(5ms);
         }
 
-        REQUIRE(gul14::toc(t0) >= 0.02);
+        REQUIRE(gul17::toc(t0) >= 0.02);
         REQUIRE(step2_seen_running == true);
 
         // Thread has now finished. As long as we do not start another one, update() keeps
@@ -236,7 +236,7 @@ TEST_CASE("Executor: run_single_step_asynchronously()", "[Executor]")
         while (executor.update(sequence))
         {
             REQUIRE(sequence[1].is_running() == false);
-            gul14::sleep(5ms);
+            gul17::sleep(5ms);
         }
 
         REQUIRE(sequence.is_running() == false);
@@ -265,11 +265,11 @@ TEST_CASE("Executor: cancel() endless step loop", "[Executor]")
 
     executor.run_asynchronously(sequence, context);
 
-    gul14::sleep(1ms);
+    gul17::sleep(1ms);
     executor.cancel(sequence);
 
     while (executor.update(sequence)) {
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
     }
 
     // Make sure that exactly the desired error message comes out
@@ -290,7 +290,7 @@ TEST_CASE("Executor: Destruct while Lua script is running", "[Executor]")
     {
         Executor executor;
         executor.run_asynchronously(sequence, context);
-        gul14::sleep(1ms);
+        gul17::sleep(1ms);
     } // executor is destructed here
 
     REQUIRE(sequence.get_error().has_value() == false);
@@ -309,15 +309,15 @@ TEST_CASE("Executor: cancel() within Lua sleep()", "[Executor]")
 
     Executor executor;
 
-    const auto t0 = gul14::tic();
+    const auto t0 = gul17::tic();
 
     executor.run_asynchronously(sequence, context);
 
-    gul14::sleep(5ms);
+    gul17::sleep(5ms);
     executor.cancel();
 
-    REQUIRE(gul14::toc(t0) >= 0.005);
-    REQUIRE(gul14::toc(t0) < 0.2);
+    REQUIRE(gul17::toc(t0) >= 0.005);
+    REQUIRE(gul17::toc(t0) < 0.2);
 
     // Thread has now finished. As long as we do not start another one, update() keeps
     // returning false.
@@ -364,15 +364,15 @@ TEST_CASE("Executor: cancel() within pcalls and CATCH blocks", "[Executor]")
 
     Executor executor;
 
-    const auto t0 = gul14::tic();
+    const auto t0 = gul17::tic();
 
     executor.run_asynchronously(sequence, context);
 
-    gul14::sleep(5ms);
+    gul17::sleep(5ms);
     executor.cancel();
 
-    REQUIRE(gul14::toc(t0) >= 0.005);
-    REQUIRE(gul14::toc(t0) < 0.2);
+    REQUIRE(gul17::toc(t0) >= 0.005);
+    REQUIRE(gul17::toc(t0) < 0.2);
 
     // Thread has now finished. As long as we do not start another one, update() keeps
     // returning false.
@@ -408,7 +408,7 @@ TEST_CASE("Executor: Redirection of print() output", "[Executor]")
     executor.run_asynchronously(sequence, context);
 
     while (executor.update(sequence))
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
 
     REQUIRE(output == "Mary had\t3\tlittle lambs.\n");
 }
@@ -428,14 +428,14 @@ TEST_CASE("Executor: Access context after run", "[Executor]")
         seq.modify(s, [](Step& step) { step.set_used_context_variable_names(VariableNames{ "a" }); });
 
     // Execute directly
-    REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+    REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
     REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 11 );
 
     // Execute async
     Executor executor{ };
     executor.run_asynchronously(seq, ctx);
     while (executor.update(seq))
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
     auto vars = executor.get_context_variables();
     REQUIRE(std::get<VarInteger>(vars["a"]) == 21);
 }
@@ -491,7 +491,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with explict termination",
 
     // Process messages as long as the thread is running
     while (executor.update(seq))
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
 
     // Thread has now finished. As long as we do not start another one, update() keeps
     // returning false.
@@ -540,7 +540,7 @@ TEST_CASE("Executor: Run a sequence asynchronously with throw", "[Executor]")
     REQUIRE(seq.is_running() == true);
 
     while (executor.update(seq))
-        gul14::sleep(5ms);
+        gul17::sleep(5ms);
 
     REQUIRE(executor.update(seq) == false);
 
@@ -593,7 +593,7 @@ TEST_CASE("Executor: Message callbacks", "[execute_sequence]")
         executor.run_asynchronously(sequence, context);
 
         while (executor.update(sequence))
-            gul14::sleep(5ms);
+            gul17::sleep(5ms);
 
         REQUIRE(str ==
             "[SEQ_START]"
@@ -616,7 +616,7 @@ TEST_CASE("Executor: Message callbacks", "[execute_sequence]")
         executor.run_asynchronously(sequence, context);
 
         while (executor.update(sequence))
-            gul14::sleep(5ms);
+            gul17::sleep(5ms);
 
         REQUIRE(str ==
             "[SEQ_START]"

--- a/tests/test_LockedQueue.cc
+++ b/tests/test_LockedQueue.cc
@@ -27,7 +27,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <gul14/time_util.h>
+#include <gul17/time_util.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/Message.h"
@@ -134,7 +134,7 @@ TEST_CASE("LockedQueue: push() & pop() across threads", "[LockedQueue]")
                 queue.push(MyMessage(i));
         });
 
-    gul14::sleep(0.005);
+    gul17::sleep(0.005);
     // Pull all 100 messages out of the queue from the main thread
     for (int i = 1; i <= 100; ++i)
     {
@@ -168,7 +168,7 @@ TEST_CASE("LockedQueue: try_pop() single-threaded", "[LockedQueue]")
     LockedQueue<int> queue{ 2 };
     REQUIRE(queue.size() == 0);
 
-    REQUIRE(queue.try_pop() == gul14::nullopt);
+    REQUIRE(queue.try_pop() == std::nullopt);
 
     queue.push(1);
     queue.push(2);
@@ -182,7 +182,7 @@ TEST_CASE("LockedQueue: try_pop() single-threaded", "[LockedQueue]")
     REQUIRE(opt.has_value());
     REQUIRE(*opt == 2);
 
-    REQUIRE(queue.try_pop() == gul14::nullopt);
+    REQUIRE(queue.try_pop() == std::nullopt);
 }
 
 TEST_CASE("LockedQueue: try_push() single-threaded", "[LockedQueue]")
@@ -232,7 +232,7 @@ TEST_CASE("LockedQueue: try_push() & try_pop() across threads", "[LockedQueue]")
     // Pull all 100 messages out of the queue from the main thread
     for (int i = 1; i <= 100; ++i)
     {
-        gul14::optional<MyMessage> opt_msg;
+        std::optional<MyMessage> opt_msg;
         do
         {
             opt_msg = queue.try_pop();

--- a/tests/test_LockedQueue.cc
+++ b/tests/test_LockedQueue.cc
@@ -4,7 +4,7 @@
  * \date   Created on April 1, 2022
  * \brief  Test suite for the LockedQueue class template.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,8 +24,11 @@
 
 #include <thread>
 #include <type_traits>
-#include <gul14/catch.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <gul14/time_util.h>
+
 #include "taskolib/exceptions.h"
 #include "taskolib/Message.h"
 #include "taskolib/LockedQueue.h"

--- a/tests/test_Message.cc
+++ b/tests/test_Message.cc
@@ -27,7 +27,7 @@
 #include <type_traits>
 
 #include <catch2/catch_test_macros.hpp>
-#include <gul14/trim.h>
+#include <gul17/trim.h>
 
 #include "taskolib/Message.h"
 #include "taskolib/Sequence.h"
@@ -111,7 +111,7 @@ TEST_CASE("Message: set_index()", "[Message]")
     REQUIRE(msg.get_index().has_value() == true);
     REQUIRE(*(msg.get_index()) == 0);
 
-    msg.set_index(gul14::nullopt);
+    msg.set_index(std::nullopt);
     REQUIRE(msg.get_index().has_value() == false);
 }
 
@@ -160,11 +160,11 @@ TEST_CASE("Message: Dump to stream", "[Message]")
 
     std::stringstream ss{ };
     ss << msg;
-    REQUIRE(gul14::trim(ss.str()) == "Message{ 32: step_started \"Beware of the foxes\" 1970-01-01 00:00:00 UTC }");
+    REQUIRE(gul17::trim(ss.str()) == "Message{ 32: step_started \"Beware of the foxes\" 1970-01-01 00:00:00 UTC }");
 
     // msg.set_type(Message::Type::output); We don't have that yet
     msg.set_text("Lua print() has been called\n");
     ss.str(""s);
     ss << msg;
-    REQUIRE(gul14::trim(ss.str()) == "Message{ 32: step_started \"Lua print() has been called\\n\" 1970-01-01 00:00:00 UTC }");
+    REQUIRE(gul17::trim(ss.str()) == "Message{ 32: step_started \"Lua print() has been called\\n\" 1970-01-01 00:00:00 UTC }");
 }

--- a/tests/test_Message.cc
+++ b/tests/test_Message.cc
@@ -4,7 +4,7 @@
  * \date   Created on April 1, 2022
  * \brief  Test suite for the Message class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,7 +26,7 @@
 #include <thread>
 #include <type_traits>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 #include <gul14/trim.h>
 
 #include "taskolib/Message.h"

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -4,7 +4,7 @@
  * \date    Created on February 8, 2022
  * \brief   Test suite for the the Sequence class.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,8 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <gul14/time_util.h>
 
 #include "taskolib/Sequence.h"
@@ -30,7 +31,7 @@
 using namespace std::literals;
 using namespace task;
 using namespace task::literals;
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 
 TEST_CASE("Sequence: Constructor", "[Sequence]")
 {
@@ -3777,7 +3778,7 @@ TEST_CASE("execute(): Single step", "[Sequence]")
     {
         auto maybe_error = sequence.execute(context, nullptr, 2);
         REQUIRE(maybe_error.has_value());
-        REQUIRE_THAT(maybe_error->what(), Contains("Action Boom"));
+        REQUIRE_THAT(maybe_error->what(), ContainsSubstring("Action Boom"));
         REQUIRE(maybe_error->get_index().has_value());
         REQUIRE(maybe_error->get_index().value() == 2);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 3 });
@@ -4034,7 +4035,7 @@ TEST_CASE("Sequence: sequence timeout", "[Sequence]")
     REQUIRE(seq.get_time_of_last_execution() != task::TimePoint{});
 
     REQUIRE(maybe_error.has_value());
-    REQUIRE_THAT(maybe_error->what(), Contains("Timeout: Sequence"));
+    REQUIRE_THAT(maybe_error->what(), ContainsSubstring("Timeout: Sequence"));
 }
 
 TEST_CASE("Sequence: add maintainer", "[Sequence]")

--- a/tests/test_Sequence.cc
+++ b/tests/test_Sequence.cc
@@ -24,7 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <gul14/time_util.h>
+#include <gul17/time_util.h>
 
 #include "taskolib/Sequence.h"
 
@@ -216,7 +216,7 @@ TEST_CASE("Sequence: get_error()", "[Sequence]")
     Sequence seq{ "test_sequence" };
     REQUIRE(seq.get_error().has_value() == false);
 
-    seq.set_error(Error{ "Test", gul14::nullopt });
+    seq.set_error(Error{ "Test", std::nullopt });
     REQUIRE(seq.get_error().has_value());
     REQUIRE(seq.get_error()->what() == "Test"s);
     REQUIRE(seq.get_error()->get_index().has_value() == false);
@@ -343,7 +343,7 @@ TEST_CASE("Sequence: is_running()", "[Sequence]")
     REQUIRE(not seq.is_running());
 
     Context ctx;
-    REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+    REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
 
     REQUIRE(not seq.is_running());
 
@@ -495,7 +495,7 @@ TEST_CASE("Sequence: set_error()", "[Sequence]")
     REQUIRE(seq.get_error()->get_index().has_value());
     REQUIRE(seq.get_error()->get_index().value() == 42);
 
-    seq.set_error(gul14::nullopt);
+    seq.set_error(std::nullopt);
     REQUIRE(seq.get_error().has_value() == false);
 }
 
@@ -1277,7 +1277,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         s1.set_script("a = 2");
 
         seq.push_back(s1);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 0);
     }
     SECTION("Manipulate context variable") {
@@ -1286,7 +1286,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         s1.set_used_context_variable_names(VariableNames{"a"});
 
         seq.push_back(s1);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over (not)") {
@@ -1298,7 +1298,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.push_back(s2);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 2);
     }
     SECTION("Hand context variable over") {
@@ -1311,7 +1311,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.push_back(s2);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand variable over context without initial value") {
@@ -1324,7 +1324,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.push_back(s2);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
     }
     SECTION("Hand bool variable over context without initial value") {
@@ -1337,7 +1337,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
 
         seq.push_back(s1);
         seq.push_back(s2);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         CAPTURE(std::get<VarInteger>(ctx.variables["a"]));
         REQUIRE(ctx.variables["a"] == VariableValue{ VarInteger{ 4 }}); // Another variant to check variables
     }
@@ -1355,7 +1355,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s1);
         seq.push_back(s2);
         seq.push_back(s3);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         CAPTURE(std::get<VarInteger>(ctx.variables["a"]));
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 4);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
@@ -1383,7 +1383,7 @@ TEST_CASE("execute(): Simple sequence with more context variables", "[Sequence]"
         seq.push_back(s2);
         seq.push_back(s3);
         seq.push_back(s4);
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         CAPTURE(std::get<VarInteger>(ctx.variables["a"]));
         REQUIRE(std::get<VarInteger>(ctx.variables["a"]) == 1);
         REQUIRE_THROWS(ctx.variables.at("b")); // nil means not-existing
@@ -3028,7 +3028,7 @@ TEST_CASE("execute_sequence(): Messages", "[execute_sequence]")
     sequence.push_back(std::move(step1));
     sequence.push_back(std::move(step2));
 
-    REQUIRE(sequence.execute(context, &comm) == gul14::nullopt);
+    REQUIRE(sequence.execute(context, &comm) == std::nullopt);
 
     // 2 sequence messages plus 4 step start/stop messages
     REQUIRE(queue.size() == 6);
@@ -3111,7 +3111,7 @@ TEST_CASE("execute_sequence(): Message callbacks", "[execute_sequence]")
         sequence.push_back(std::move(step1));
         sequence.push_back(std::move(step2));
 
-        REQUIRE(sequence.execute(context, nullptr) == gul14::nullopt);
+        REQUIRE(sequence.execute(context, nullptr) == std::nullopt);
 
         REQUIRE(str ==
             "[SEQ_START]"
@@ -3131,7 +3131,7 @@ TEST_CASE("execute_sequence(): Message callbacks", "[execute_sequence]")
         sequence.push_back(std::move(step1));
         sequence.push_back(std::move(step2));
 
-        REQUIRE(sequence.execute(context, nullptr) != gul14::nullopt);
+        REQUIRE(sequence.execute(context, nullptr) != std::nullopt);
 
         REQUIRE(str ==
             "[SEQ_START]"
@@ -3764,13 +3764,13 @@ TEST_CASE("execute(): Single step", "[Sequence]")
 
     SECTION("Index 0 (END step): Script is not executed because of the step type")
     {
-        REQUIRE(sequence.execute(context, nullptr, 0) == gul14::nullopt);
+        REQUIRE(sequence.execute(context, nullptr, 0) == std::nullopt);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 0 });
     }
 
     SECTION("Index 1 (WHILE step): Script is executed")
     {
-        REQUIRE(sequence.execute(context, nullptr, 1) == gul14::nullopt);
+        REQUIRE(sequence.execute(context, nullptr, 1) == std::nullopt);
         REQUIRE(std::get<VarInteger>(context.variables["a"]) == VarInteger{ 2 });
     }
 
@@ -3825,7 +3825,7 @@ TEST_CASE("Sequence: terminate sequence with Lua exit function", "[Sequence]")
     seq.push_back(step_check_termination);
     seq.push_back(step_while_end);
 
-    REQUIRE(seq.execute(ctx, &comm) == gul14::nullopt);
+    REQUIRE(seq.execute(ctx, &comm) == std::nullopt);
 
     // Both the sequence and all of its steps must show is_running() == false.
     REQUIRE(seq.is_running() == false);
@@ -3861,7 +3861,7 @@ TEST_CASE("Sequence: add step setup with variable", "[Sequence]")
     seq.push_back(step_action_2);
     seq.set_step_setup_script("preface = 'Alice calls '");
 
-    REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+    REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
 
     REQUIRE(std::get<std::string>(ctx.variables["a"]) == "Alice calls Bob");
     REQUIRE(std::get<std::string>(ctx.variables["b"]) == "Alice calls Bob and Alice"
@@ -3888,7 +3888,7 @@ TEST_CASE("Sequence: add step setup with function", "[Sequence]")
     seq.push_back(step_action_2);
     seq.set_step_setup_script("function preface(name) return 'Alice calls ' .. name end");
 
-    REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+    REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
 
     REQUIRE(std::get<std::string>(ctx.variables["a"]) == "Alice calls Bob!");
     REQUIRE(std::get<std::string>(ctx.variables["b"]) == "Alice calls Charlie and"
@@ -3926,7 +3926,7 @@ TEST_CASE("Sequence: add step setup with isolated function modification", "[Sequ
     seq.push_back(step_action_3);
     seq.set_step_setup_script("function preface(name) return 'Alice calls ' .. name end");
 
-    REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+    REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
 
     REQUIRE(std::get<VarString>(ctx.variables["a"]) == "Alice calls Bob!");
     REQUIRE(std::get<VarString>(ctx.variables["b"]) == "Alice calls Charlie!");
@@ -4013,7 +4013,7 @@ TEST_CASE("Sequence: Check setter/getter function for step setup script", "[Sequ
         Context ctx;
         REQUIRE(ctx.step_setup_script.empty());
 
-        REQUIRE(seq.execute(ctx, nullptr) == gul14::nullopt);
+        REQUIRE(seq.execute(ctx, nullptr) == std::nullopt);
         REQUIRE(ctx.step_setup_script == script);
     }
 }

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -4,7 +4,7 @@
  * \date    Created on July 22, 2022
  * \brief   Test suite for the SequenceManager class.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -29,7 +29,9 @@
 #include <utility>
 #include <vector>
 
-#include <gul14/catch.h>
+#include <catch2/catch_case_sensitive.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <gul14/finalizer.h>
 #include <gul14/substring_checks.h>
 #include <libgit4cpp/Repository.h>
@@ -853,8 +855,8 @@ TEST_CASE("SequenceManager: fail creating sequence", "[SequenceManager]")
     });
 
     CHECK_THROWS_WITH(new SequenceManager{ dir },
-        Contains("git", CaseSensitive::No)
-        and Contains("init", CaseSensitive::No));
+        ContainsSubstring("git", CaseSensitive::No)
+        and ContainsSubstring("init", CaseSensitive::No));
 }
 
 TEST_CASE("SequenceManager: fail storing sequence", "[SequenceManager]")
@@ -884,6 +886,6 @@ TEST_CASE("SequenceManager: fail storing sequence", "[SequenceManager]")
     });
 
     CHECK_THROWS_WITH(manager.store_sequence(seq),
-        Contains("I/O", CaseSensitive::No)
-        and Contains("permission", CaseSensitive::No));
+        ContainsSubstring("I/O", CaseSensitive::No)
+        and ContainsSubstring("permission", CaseSensitive::No));
 }

--- a/tests/test_SequenceManager.cc
+++ b/tests/test_SequenceManager.cc
@@ -32,8 +32,8 @@
 #include <catch2/catch_case_sensitive.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <gul14/finalizer.h>
-#include <gul14/substring_checks.h>
+#include <gul17/finalizer.h>
+#include <gul17/substring_checks.h>
 #include <libgit4cpp/Repository.h>
 
 #include "internals.h"
@@ -72,7 +72,7 @@ std::vector<std::string> collect_lua_filenames(const std::filesystem::path& path
     return result;
 }
 
-gul14::optional<SequenceManager::SequenceOnDisk> find_sequence_by_name(std::vector<SequenceManager::SequenceOnDisk> const& list, gul14::string_view name) {
+std::optional<SequenceManager::SequenceOnDisk> find_sequence_by_name(std::vector<SequenceManager::SequenceOnDisk> const& list, std::string_view name) {
     for (auto const& s : list)
         if (s.name.string() == name)
             return s;
@@ -311,7 +311,7 @@ TEST_CASE("parse_folder_name()", "[SequenceManager]")
         == SequenceManager::SequenceOnDisk{
             "[1234567890abcdef]", SequenceName{ "" }, 0x1234567890abcdef_uid });
     REQUIRE(SequenceManager::parse_folder_name("A$2f$22sequence$22$24$3cagain$3e [my_uid]")
-        == gul14::nullopt);
+        == std::nullopt);
 }
 
 TEST_CASE("SequenceManager: remove_sequence()", "[SequenceManager]")
@@ -438,7 +438,7 @@ TEST_CASE("SequenceManager: store_sequence() & load_sequence() - Steps",
             and lhs.get_label() == rhs.get_label()
             and lhs.get_script() == rhs.get_script();
         if (not r)
-            WARN(gul14::cat("Step '", lhs.get_label(), "' is unequal."));
+            WARN(gul17::cat("Step '", lhs.get_label(), "' is unequal."));
         return r;
     };
 
@@ -631,7 +631,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            if (not gul14::starts_with(elm.path_name, "git_sequence_1"))
+            if (not gul17::starts_with(elm.path_name, "git_sequence_1"))
                 continue;
             seq_exists = true;
 
@@ -679,7 +679,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            if (not gul14::starts_with(elm.path_name, "git_sequence_1[0000abcdef123456]/sequence.lua"))
+            if (not gul17::starts_with(elm.path_name, "git_sequence_1[0000abcdef123456]/sequence.lua"))
                 continue;
             seq_exists = true;
 
@@ -715,7 +715,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         REQUIRE(s2->path != "");
 
         // check commit message
-        const std::string expected_msg = gul14::cat("Copy sequence git_sequence_1[0000abcdef123456] "
+        const std::string expected_msg = gul17::cat("Copy sequence git_sequence_1[0000abcdef123456] "
             "to ", s2->path.string(), "\n\n"
             "- new file: sequence.lua\n"
             "- new file: step_1_while.lua");
@@ -728,7 +728,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            if (gul14::starts_with(elm.path_name, "git_sequence_2"))
+            if (gul17::starts_with(elm.path_name, "git_sequence_2"))
             {
                 seq_exists = true;
 
@@ -766,7 +766,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
 
         git::Repository repo{ git_dir };
 
-        const std::string expected_msg = gul14::cat("Rename ",
+        const std::string expected_msg = gul17::cat("Rename ",
             s2->path.string(), " to ", s3->path.string(), "\n\n"
             "- deleted: sequence.lua\n"
             "- deleted: step_1_while.lua\n"
@@ -782,7 +782,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
         bool seq_exists = false;
         for(const auto& elm: stats)
         {
-            if (gul14::starts_with(elm.path_name, "git_sequence_3"))
+            if (gul17::starts_with(elm.path_name, "git_sequence_3"))
             {
                 seq_exists = true;
 
@@ -829,7 +829,7 @@ TEST_CASE("SequenceManager: git repository", "[SequenceManager]")
             // if commit did not work
             //      elm.handling == "staged"
             //      elm.changes == "deleted"
-            REQUIRE(! gul14::starts_with(elm.path_name, "git_sequence_1"));
+            REQUIRE(! gul17::starts_with(elm.path_name, "git_sequence_1"));
         }
         // check if sequence got removed from index
         REQUIRE(! seq_exists);
@@ -846,7 +846,7 @@ TEST_CASE("SequenceManager: fail creating sequence", "[SequenceManager]")
         std::filesystem::perms::owner_write,
         std::filesystem::perm_options::remove
     );
-    auto _ = gul14::finally([dir]() {
+    auto _ = gul17::finally([dir]() {
         std::filesystem::permissions(
             dir,
             std::filesystem::perms::owner_write,
@@ -877,7 +877,7 @@ TEST_CASE("SequenceManager: fail storing sequence", "[SequenceManager]")
         std::filesystem::perms::owner_write,
         std::filesystem::perm_options::remove
     );
-    auto _ = gul14::finally([d]() {
+    auto _ = gul17::finally([d]() {
         std::filesystem::permissions(
             d,
             std::filesystem::perms::owner_write,

--- a/tests/test_SequenceName.cc
+++ b/tests/test_SequenceName.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 27, 2023
  * \brief  Test suite for the SequenceName class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,7 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/SequenceName.h"

--- a/tests/test_SequenceName.cc
+++ b/tests/test_SequenceName.cc
@@ -56,12 +56,12 @@ TEST_CASE("SequenceName: from_string()", "[SequenceName]")
             == SequenceName{ "extremely-weird-combination" });
     REQUIRE(SequenceName::from_string("a.b-C_D") == SequenceName{ "a.b-C_D" });
 
-    REQUIRE(SequenceName::from_string(std::string(SequenceName::max_length + 1, 'a')) == gul14::nullopt);
-    REQUIRE(SequenceName::from_string("string with whitespace") == gul14::nullopt);
-    REQUIRE(SequenceName::from_string("abcd#e") == gul14::nullopt);
-    REQUIRE(SequenceName::from_string("abcd(e)") == gul14::nullopt);
-    REQUIRE(SequenceName::from_string("abcd[e]") == gul14::nullopt);
-    REQUIRE(SequenceName::from_string(".abcd") == gul14::nullopt);
+    REQUIRE(SequenceName::from_string(std::string(SequenceName::max_length + 1, 'a')) == std::nullopt);
+    REQUIRE(SequenceName::from_string("string with whitespace") == std::nullopt);
+    REQUIRE(SequenceName::from_string("abcd#e") == std::nullopt);
+    REQUIRE(SequenceName::from_string("abcd(e)") == std::nullopt);
+    REQUIRE(SequenceName::from_string("abcd[e]") == std::nullopt);
+    REQUIRE(SequenceName::from_string(".abcd") == std::nullopt);
 }
 
 TEST_CASE("SequenceName: operator==()", "[SequenceName]")

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -4,7 +4,7 @@
  * \date   Created on November 26, 2021
  * \brief  Test suite for the Step class.
  *
- * \copyright Copyright 2021-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,7 +25,8 @@
 #include <stdexcept>
 #include <type_traits>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <gul14/time_util.h>
 
 #include "taskolib/exceptions.h"
@@ -33,7 +34,7 @@
 
 using namespace std::literals;
 using namespace task;
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::StartsWith;
 
 TEST_CASE("Step: Default constructor", "[Step]")
@@ -389,7 +390,7 @@ TEST_CASE("execute(): Lua exceptions", "[Step]")
         }
         catch (const Error& e)
         {
-            REQUIRE_THAT(e.what(), Contains("syntax error"));
+            REQUIRE_THAT(e.what(), ContainsSubstring("syntax error"));
             REQUIRE(e.get_index().has_value());
             REQUIRE(e.get_index().value() == 42);
         }

--- a/tests/test_Step.cc
+++ b/tests/test_Step.cc
@@ -27,7 +27,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <gul14/time_util.h>
+#include <gul17/time_util.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/Step.h"
@@ -504,9 +504,9 @@ TEST_CASE("execute(): Custom commands", "[Step]")
     {
         step.set_script("sleep(0.001)");
 
-        auto t0 = gul14::tic();
+        auto t0 = gul17::tic();
         step.execute(context);
-        REQUIRE(gul14::toc(t0) >= 0.001);
+        REQUIRE(gul17::toc(t0) >= 0.001);
     }
 }
 
@@ -517,27 +517,27 @@ TEST_CASE("execute(): Timeout", "[Step]")
 
     SECTION("Simple infinite loop is terminated")
     {
-        auto t0 = gul14::tic();
+        auto t0 = gul17::tic();
         step.set_script("while true do end; return true");
         step.set_timeout(20ms);
         REQUIRE_THROWS_AS(step.execute(context), Error);
-        REQUIRE(gul14::toc<std::chrono::milliseconds>(t0) >= 20);
-        REQUIRE(gul14::toc<std::chrono::milliseconds>(t0) < 200); // leave some time for system hiccups
+        REQUIRE(gul17::toc<std::chrono::milliseconds>(t0) >= 20);
+        REQUIRE(gul17::toc<std::chrono::milliseconds>(t0) < 200); // leave some time for system hiccups
     }
 
     SECTION("sleep() is terminated")
     {
-        auto t0 = gul14::tic();
+        auto t0 = gul17::tic();
         step.set_script("sleep(10)");
         step.set_timeout(5ms);
         REQUIRE_THROWS_AS(step.execute(context), Error);
-        REQUIRE(gul14::toc<std::chrono::milliseconds>(t0) >= 5);
-        REQUIRE(gul14::toc<std::chrono::milliseconds>(t0) < 200); // leave some time for system hiccups
+        REQUIRE(gul17::toc<std::chrono::milliseconds>(t0) >= 5);
+        REQUIRE(gul17::toc<std::chrono::milliseconds>(t0) < 200); // leave some time for system hiccups
     }
 
     SECTION("Infinite loop is terminated despite pcall protection")
     {
-        auto t0 = gul14::tic();
+        auto t0 = gul17::tic();
         step.set_script(R"(
             local function infinite_loop()
                 while true do
@@ -552,8 +552,8 @@ TEST_CASE("execute(): Timeout", "[Step]")
             )");
         step.set_timeout(20ms);
         REQUIRE_THROWS_AS(step.execute(context), Error);
-        REQUIRE(gul14::toc<std::chrono::milliseconds>(t0) >= 20);
-        REQUIRE(gul14::toc<std::chrono::milliseconds>(t0) < 200); // leave some time for system hiccups
+        REQUIRE(gul17::toc<std::chrono::milliseconds>(t0) >= 20);
+        REQUIRE(gul17::toc<std::chrono::milliseconds>(t0) < 200); // leave some time for system hiccups
     }
 }
 

--- a/tests/test_Tag.cc
+++ b/tests/test_Tag.cc
@@ -25,7 +25,7 @@
 #include <sstream>
 
 #include <catch2/catch_test_macros.hpp>
-#include <gul14/join_split.h>
+#include <gul17/join_split.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/Tag.h"
@@ -143,8 +143,8 @@ TEST_CASE("Tag: string()", "[Tag]")
     REQUIRE(Tag{ "-1-a-B-C-" }.string() == "-1-a-b-c-");
 }
 
-TEST_CASE("Tag: Usability with gul14::join()", "[Tag]")
+TEST_CASE("Tag: Usability with gul17::join()", "[Tag]")
 {
     std::vector tags{ Tag{ "a" }, Tag{ "b" }, Tag{ "c" } };
-    REQUIRE(gul14::join(tags, ", ") == "a, b, c");
+    REQUIRE(gul17::join(tags, ", ") == "a, b, c");
 }

--- a/tests/test_Tag.cc
+++ b/tests/test_Tag.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 17, 2024
  * \brief  Test suite for the Tag class.
  *
- * \copyright Copyright 2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2024-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,7 +24,7 @@
 
 #include <sstream>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 #include <gul14/join_split.h>
 
 #include "taskolib/exceptions.h"

--- a/tests/test_Timeout.cc
+++ b/tests/test_Timeout.cc
@@ -4,7 +4,7 @@
  * \date   Created on November 28, 2022
  * \brief  Test suite for the Timeout class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,13 +26,12 @@
 #include <stdexcept>
 #include <sstream>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "taskolib/Timeout.h"
 
 using namespace std::literals;
 using namespace task;
-using namespace Catch::Matchers;
 
 TEST_CASE("Timeout: Default constructor", "[Timeout]")
 {

--- a/tests/test_TimeoutTrigger.cc
+++ b/tests/test_TimeoutTrigger.cc
@@ -23,7 +23,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <catch2/catch_test_macros.hpp>
-#include <gul14/time_util.h>
+#include <gul17/time_util.h>
 
 #include "taskolib/TimeoutTrigger.h"
 
@@ -91,6 +91,6 @@ TEST_CASE("TimeoutTrigger: check elapsed timeout", "[TimeoutTrigger]")
 
     timeout_trigger.set_timeout(200ms);
 
-    gul14::sleep(10ms);
+    gul17::sleep(10ms);
     REQUIRE(timeout_trigger.is_elapsed() == true);
 }

--- a/tests/test_TimeoutTrigger.cc
+++ b/tests/test_TimeoutTrigger.cc
@@ -4,7 +4,7 @@
  * \date   Created on February 21, 2023
  * \brief  Test suite for the TriggerTimeout class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,7 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 #include <gul14/time_util.h>
 
 #include "taskolib/TimeoutTrigger.h"

--- a/tests/test_UniqueId.cc
+++ b/tests/test_UniqueId.cc
@@ -4,7 +4,7 @@
  * \date   Created on July 27, 2023
  * \brief  Test suite for the UniqueId class.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,7 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/UniqueId.h"

--- a/tests/test_UniqueId.cc
+++ b/tests/test_UniqueId.cc
@@ -22,6 +22,9 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <algorithm>
+#include <array>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "taskolib/exceptions.h"

--- a/tests/test_VariableName.cc
+++ b/tests/test_VariableName.cc
@@ -4,7 +4,7 @@
  * \date   Created on January 6, 2022
  * \brief  Test suite for the VariableName class.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,8 +23,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <array>
-#include <gul14/catch.h>
+
+#include <catch2/catch_test_macros.hpp>
 #include <gul14/join_split.h>
+
 #include "taskolib/exceptions.h"
 #include "taskolib/VariableName.h"
 

--- a/tests/test_VariableName.cc
+++ b/tests/test_VariableName.cc
@@ -25,7 +25,7 @@
 #include <array>
 
 #include <catch2/catch_test_macros.hpp>
-#include <gul14/join_split.h>
+#include <gul17/join_split.h>
 
 #include "taskolib/exceptions.h"
 #include "taskolib/VariableName.h"
@@ -151,9 +151,9 @@ TEST_CASE("VariableName: size()", "[VariableName]")
     REQUIRE(VariableName{ "pippo" }.size() == 5);
 }
 
-TEST_CASE("VariableName: Compatibility with gul14::join()", "[VariableName]")
+TEST_CASE("VariableName: Compatibility with gul17::join()", "[VariableName]")
 {
     const std::array<VariableName, 3> vars{ "a", "bb", "ccc" };
 
-    REQUIRE(gul14::join(vars, ", ") == "a, bb, ccc");
+    REQUIRE(gul17::join(vars, ", ") == "a, bb, ccc");
 }

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -1,10 +1,10 @@
 /**
- * \file   test_deserialize_sequence.cc
- * \author Lars Fröhlich, Marcus Walla
- * \date   Created on July 26, 2023
- * \brief  Test suite for free functions declared in deserialize_sequence.h.
+ * \file    test_deserialize_sequence.cc
+ * \authors Lars Fröhlich, Marcus Walla
+ * \date    Created on July 26, 2023
+ * \brief   Test suite for free functions declared in deserialize_sequence.h.
  *
- * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,7 +25,7 @@
 #include <filesystem>
 #include <fstream>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "deserialize_sequence.h"
 #include "internals_unit_test.h"

--- a/tests/test_deserialize_sequence.cc
+++ b/tests/test_deserialize_sequence.cc
@@ -88,7 +88,7 @@ TEST_CASE("Ancient sequence", "[deserialize_sequence]")
         std::ofstream stream(path);
 
         if (stream.fail())
-            FAIL(gul14::cat("Could not create file: " + path.string()));
+            FAIL(gul17::cat("Could not create file: " + path.string()));
 
         stream << "-- label: some label\n";
         stream.close();
@@ -103,7 +103,7 @@ TEST_CASE("Ancient sequence", "[deserialize_sequence]")
         std::ofstream stream(path);
 
         if (stream.fail())
-            FAIL(gul14::cat("Could not create file: " + path.string()));
+            FAIL(gul17::cat("Could not create file: " + path.string()));
 
         stream << "-- label: some label\n";
         stream << "-- autorun: true\n";
@@ -119,7 +119,7 @@ TEST_CASE("Ancient sequence", "[deserialize_sequence]")
         std::ofstream stream(path);
 
         if (stream.fail())
-            FAIL(gul14::cat("Could not create file: " + path.string()));
+            FAIL(gul17::cat("Could not create file: " + path.string()));
 
         stream << "-- label: some label\n";
         stream << "-- disabled: true\n";

--- a/tests/test_exceptions.cc
+++ b/tests/test_exceptions.cc
@@ -72,23 +72,23 @@ TEST_CASE("Error: Copy assignment", "[exceptions]")
 TEST_CASE("Error: operator==", "[exceptions]")
 {
     REQUIRE(Error("Test", 42) == Error("Test", 42));
-    REQUIRE(Error("Test", gul14::nullopt) == Error("Test", gul14::nullopt));
+    REQUIRE(Error("Test", std::nullopt) == Error("Test", std::nullopt));
     REQUIRE(Error("", 42) == Error("", 42));
 
     REQUIRE_FALSE(Error("test", 42) == Error("TEST", 42));
     REQUIRE_FALSE(Error("test", 42) == Error("test", 23));
-    REQUIRE_FALSE(Error("Test", 13) == Error("Test", gul14::nullopt));
-    REQUIRE_FALSE(Error(" ", gul14::nullopt) == Error("", gul14::nullopt));
+    REQUIRE_FALSE(Error("Test", 13) == Error("Test", std::nullopt));
+    REQUIRE_FALSE(Error(" ", std::nullopt) == Error("", std::nullopt));
 }
 
 TEST_CASE("Error: operator!=", "[exceptions]")
 {
     REQUIRE_FALSE(Error("Test", 42) != Error("Test", 42));
-    REQUIRE_FALSE(Error("Test", gul14::nullopt) != Error("Test", gul14::nullopt));
+    REQUIRE_FALSE(Error("Test", std::nullopt) != Error("Test", std::nullopt));
     REQUIRE_FALSE(Error("", 42) != Error("", 42));
 
     REQUIRE(Error("test", 42) != Error("TEST", 42));
     REQUIRE(Error("test", 42) != Error("test", 23));
-    REQUIRE(Error("Test", 13) != Error("Test", gul14::nullopt));
-    REQUIRE(Error(" ", gul14::nullopt) != Error("", gul14::nullopt));
+    REQUIRE(Error("Test", 13) != Error("Test", std::nullopt));
+    REQUIRE(Error(" ", std::nullopt) != Error("", std::nullopt));
 }

--- a/tests/test_exceptions.cc
+++ b/tests/test_exceptions.cc
@@ -4,7 +4,7 @@
  * \date   Created on December 10, 2021
  * \brief  Test suite for the Error exception class.
  *
- * \copyright Copyright 2021-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,7 +23,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <string>
-#include <gul14/catch.h>
+
+#include <catch2/catch_test_macros.hpp>
+
 #include "taskolib/exceptions.h"
 
 using namespace std::literals;

--- a/tests/test_execute_lua_script.cc
+++ b/tests/test_execute_lua_script.cc
@@ -24,7 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <gul14/time_util.h>
+#include <gul17/time_util.h>
 
 #include "lua_details.h"
 #include "taskolib/execute_lua_script.h"

--- a/tests/test_execute_lua_script.cc
+++ b/tests/test_execute_lua_script.cc
@@ -4,7 +4,7 @@
  * \date   Created on October 28, 2022
  * \brief  Test suite for Lua-related internal functions.
  *
- * \copyright Copyright 2022-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,7 +22,8 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <gul14/time_util.h>
 
 #include "lua_details.h"
@@ -135,8 +136,8 @@ TEST_CASE("execute_lua_script(): Lua exceptions", "[execute_lua_script]")
         auto result = execute_lua_script(
             lua, "function boom(); error('', 0); end; boom()");
         REQUIRE(result.has_value() == false);
-        REQUIRE_THAT(result.error(), not Contains("Unknown"));
-        REQUIRE_THAT(result.error(), not Contains("exception"));
+        REQUIRE_THAT(result.error(), not ContainsSubstring("Unknown"));
+        REQUIRE_THAT(result.error(), not ContainsSubstring("exception"));
     }
 
     SECTION("Runtime error, caught by pcall()")
@@ -168,8 +169,8 @@ TEST_CASE("execute_lua_script(): C++ exceptions", "[execute_lua_script]")
     {
         auto result = execute_lua_script(lua, "throw_logic_error_without_msg()");
         REQUIRE(result.has_value() == false);
-        REQUIRE_THAT(result.error(), not Contains("Unknown"));
-        REQUIRE_THAT(result.error(), not Contains("exception"));
+        REQUIRE_THAT(result.error(), not ContainsSubstring("Unknown"));
+        REQUIRE_THAT(result.error(), not ContainsSubstring("exception"));
     }
 
     SECTION("Nonstandard C++ exceptions are reported as errors")

--- a/tests/test_format.cc
+++ b/tests/test_format.cc
@@ -4,7 +4,7 @@
  * \date   Created on June 22, 2022
  * \brief  Test suite for the fmt{} library helpers.
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,8 +22,8 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
-#include <gul14/catch.h>
 #include <gul14/trim.h>
 
 #include "taskolib/Message.h"

--- a/tests/test_format.cc
+++ b/tests/test_format.cc
@@ -24,7 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <fmt/format.h>
-#include <gul14/trim.h>
+#include <gul17/trim.h>
 
 #include "taskolib/Message.h"
 #include "taskolib/time_types.h"
@@ -42,7 +42,7 @@ TEST_CASE("format: Message", "[format]")
     msg.set_index(32);
 
     auto x = fmt::format("{}", msg);
-    REQUIRE(gul14::trim(x) == "Message{ 32: step_started \"Beware of the foxes\" 1970-01-01 00:00:00 UTC }");
+    REQUIRE(gul17::trim(x) == "Message{ 32: step_started \"Beware of the foxes\" 1970-01-01 00:00:00 UTC }");
 }
 
 TEST_CASE("format: Timeout", "[format]")

--- a/tests/test_internals.cc
+++ b/tests/test_internals.cc
@@ -23,11 +23,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <catch2/catch_test_macros.hpp>
-#include <gul14/cat.h>
+#include <gul17/cat.h>
 
 #include "internals.h"
 
-using gul14::cat;
+using gul17::cat;
 using namespace task;
 
 TEST_CASE("remove_abort_markers()", "[internals]")

--- a/tests/test_internals.cc
+++ b/tests/test_internals.cc
@@ -4,7 +4,7 @@
  * \date   Created on November 4, 2022
  * \brief  Test suite for internal functions.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,14 +22,13 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <catch2/catch_test_macros.hpp>
 #include <gul14/cat.h>
-#include <gul14/catch.h>
 
 #include "internals.h"
 
 using gul14::cat;
 using namespace task;
-using namespace Catch::Matchers;
 
 TEST_CASE("remove_abort_markers()", "[internals]")
 {
@@ -58,7 +57,7 @@ TEST_CASE("remove_abort_markers()", "[internals]")
 
         SECTION("Two markers")
         {
-            auto [msg, cause] = remove_abort_markers(gul14::cat(abort_marker, abort_marker));
+            auto [msg, cause] = remove_abort_markers(cat(abort_marker, abort_marker));
             REQUIRE(cause == ErrorCause::terminated_by_script);
             REQUIRE(msg == "Script called terminate_sequence()");
         }
@@ -66,7 +65,7 @@ TEST_CASE("remove_abort_markers()", "[internals]")
         SECTION("Two markers surrounded by text")
         {
             auto [msg, cause] = remove_abort_markers(
-                gul14::cat("lorem ipsum", abort_marker, abort_marker, "dolor sit"));
+                cat("lorem ipsum", abort_marker, abort_marker, "dolor sit"));
             REQUIRE(cause == ErrorCause::terminated_by_script);
             REQUIRE(msg == "Script called terminate_sequence()");
         }
@@ -74,7 +73,7 @@ TEST_CASE("remove_abort_markers()", "[internals]")
         SECTION("Three markers surrounded by text")
         {
             auto [msg, cause] = remove_abort_markers(
-                gul14::cat("lorem ipsum", abort_marker, abort_marker, "dolor sit", abort_marker, "amet"));
+                cat("lorem ipsum", abort_marker, abort_marker, "dolor sit", abort_marker, "amet"));
             REQUIRE(cause == ErrorCause::terminated_by_script);
             REQUIRE(msg == "Script called terminate_sequence()");
         }

--- a/tests/test_lua_details.cc
+++ b/tests/test_lua_details.cc
@@ -4,7 +4,7 @@
  * \date   Created on October 28, 2022
  * \brief  Test suite for Lua-related internal functions.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,7 +24,7 @@
 
 #include <limits>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "lua_details.h"
 

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -4,7 +4,7 @@
  * \date   Created on November 26, 2019
  * \brief  Implementation of main() for the Taskolib unit test suite.
  *
- * \copyright Copyright 2021-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2021-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,8 +22,7 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#define CATCH_CONFIG_RUNNER
-#include <gul14/catch.h>
+#include <catch2/catch_session.hpp>
 
 #include "internals_unit_test.h"
 

--- a/tests/test_send_message.cc
+++ b/tests/test_send_message.cc
@@ -4,7 +4,7 @@
  * \date   Created on January 30, 2023, based on older code
  * \brief  Test suite for the send_message() function.
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,7 +24,7 @@
 
 #include <thread>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "send_message.h"
 #include "taskolib/CommChannel.h"

--- a/tests/test_serialize_sequence.cc
+++ b/tests/test_serialize_sequence.cc
@@ -4,7 +4,7 @@
  * \date   Created on May 6, 2022
  * \brief  Test suite for the free function serialize_sequence().
  *
- * \copyright Copyright 2022-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,7 +26,7 @@
 #include <filesystem>
 #include <sstream>
 
-#include <gul14/catch.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include "deserialize_sequence.h"
 #include "internals_unit_test.h"

--- a/tests/test_time_types.cc
+++ b/tests/test_time_types.cc
@@ -4,7 +4,7 @@
  * \date   Created on June 22, 2022
  * \brief  Test suite for the TimePoint class (i.e. alias).
  *
- * \copyright Copyright 2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2022-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -22,8 +22,10 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <gul14/catch.h>
+#include <random>
 #include <sstream>
+
+#include <catch2/catch_test_macros.hpp>
 
 #include "taskolib/time_types.h"
 


### PR DESCRIPTION
In this PR, we modernize the Taskolib in two regards:
- The unit test suite is migrated from the header-only Catch2 version included with GUL14 to a separately installed Catch2 in version 3.x. Apart from different header files, especially the matchers require some adaptation.
- GUL14 is replaced as a base library by GUL17. Most of these modifications are done automatically.
